### PR TITLE
Updates to nearshore survey data prep to handle missing seine data and streamline deep backscatter correction

### DIFF
--- a/Code/adjust_deep_nasc.R
+++ b/Code/adjust_deep_nasc.R
@@ -56,9 +56,12 @@ if (process.seine) {
   load(here("Output/super_clusters_hauls_ns_deep.Rdata"))
 }
 
-
-save(clf.ns.deep, hlf.ns.deep, super.clusters.ns.deep, super.hauls.ns.deep, lf.final.ns.deep, set.pie.deep, 
+# Save after processing nearshore
+save(clf.ns.deep, hlf.ns.deep, super.clusters.ns.deep, super.hauls.ns.deep, lf.final.ns.deep, 
      file = here("Output/clf_nearshore_deep.Rdata"))
+
+# Write clf.ns.deep to CSV
+write_csv(clf.ns.deep, file = here("Output/clf_nearshore_deep.csv"))
 
 # Assign backscatter to trawl clusters ------------------------------------
 cluster.match.ns.deep <- super.clusters.ns.deep %>% 
@@ -291,14 +294,7 @@ nasc.nearshore.deep <- nasc.nearshore.deep %>%
     sar.dens  = cps.nasc.deep*prop.sar  / (4*pi*sigmawg.sar)  / 1000,
     rher.dens = cps.nasc.deep*prop.rher / (4*pi*sigmawg.rher) / 1000)
 
-# Add deep density to shallow density
-nasc.nearshore <- nasc.nearshore %>% 
-  mutate(anch.dens = anch.dens + nasc.nearshore.deep$anch.dens,
-         her.dens  = her.dens  + nasc.nearshore.deep$her.dens,
-         jack.dens = jack.dens + nasc.nearshore.deep$jack.dens,
-         mack.dens = mack.dens + nasc.nearshore.deep$mack.dens,
-         sar.dens  = sar.dens  + nasc.nearshore.deep$sar.dens,
-         rher.dens = rher.dens + nasc.nearshore.deep$rher.dens)
-
 # Remove point estimates, if they exist
 if(exists("point.estimates.ns.deep")) rm(point.estimates.ns.deep)
+
+# RESUME HERE

--- a/Code/estimateNearshore.R
+++ b/Code/estimateNearshore.R
@@ -31,11 +31,6 @@ if (process.nearshore) {
                               nasc.summ.interval),
                 labels = FALSE, include.lowest = TRUE)) 
   
-  # # Summarize NASC by vessel and transect, to look for oddities
-  # nasc.nearshore %>%
-  #   group_by(vessel.name, transect) %>%
-  #   tally() %>% View()
-  
   # In 2022, LM sampled core transects between Cape Flattery and Bodega Bay spaced 20 nmi
   # Transect numbers correspond to the core transect names, and will not be unique with other
   # nearshore transects surveyed by LBC, so we must increment the transect numbers starting
@@ -116,96 +111,13 @@ if (process.nearshore) {
         cps.nasc.deep >= cps.nasc & vessel.orig %in% deep.nasc.vessels ~ cps.nasc.deep - cps.nasc,
         TRUE ~ cps.nasc))
     
-    # ggplot(nasc.nearshore, aes(cps.nasc, NASC.20)) + geom_point(aes(colour = vessel.orig)) + geom_abline(slope = 1, intercept = 0) + facet_wrap(~vessel.orig)
-    # ggplot(nasc.nearshore, aes(cps.nasc, cps.nasc.deep)) + geom_abline(slope = 1, intercept = 0) + geom_point(aes(colour = vessel.orig)) + facet_wrap(~vessel.orig)
-  }
-  
-  # Process purse seine data
-  if (process.seine) {
-    source(here("Code/processSeine.R"))
+    # Compare cps.nasc and deep.cps.nasc to look for potential errors
+    check.deep.nasc <- ggplot(nasc.nearshore, aes(cps.nasc, cps.nasc.deep)) + 
+      geom_abline(slope = 1, intercept = 0) + 
+      geom_point(aes(colour = vessel.orig)) + 
+      facet_wrap(~vessel.orig)
     
-    # if (use.seine.data) {
-    #   # In 2207RL, seine data was included in the clf, so no need to combine with seine data
-    #   # Also, this correctly applies the "adjusted" proportions of sardine and jacks in that survey
-    #   if (survey.name == "2207RL") {
-    #     # Remove LM sets north of Cape Mendocino
-    #     clf.seine      <- filter(clf.seine, lat <= 40.42)
-    #     lf.final.seine <- filter(lf.final.seine, cluster %in% unique(clf.seine$cluster))
-    #   }
-    #   
-    #   # Define variables if missing
-    #   if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
-    #   if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
-    #   if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
-    #   if (!"cluster" %in% names(hlf))     hlf$cluster <- as.numeric(NA)
-    #   
-    #   # Combine clf, hlf, and clf.seine 
-    #   clf.ns <- clf %>%
-    #     bind_rows(clf.seine) %>% 
-    #     filter(sample.type %in% catch.source.ns)
-    #   
-    #   hlf.ns <- hlf %>% 
-    #     ungroup() %>% 
-    #     bind_rows(clf.seine) %>% 
-    #     filter(sample.type %in% catch.source.ns)  
-    #   
-    #   lf.final.ns <- lf.final %>% 
-    #     bind_rows(lf.final.seine) %>% 
-    #     filter(sample.type %in% catch.source.ns)
-    #   
-    #   # Combine super clusters from the core and nearshore regions
-    #   super.hauls.ns    <- bind_rows(super.hauls, super.clusters.ns) %>% 
-    #     filter(sample.type %in% catch.source.ns)
-    #   
-    #   super.clusters.ns <- bind_rows(super.clusters, super.clusters.ns) %>% 
-    #     filter(sample.type %in% catch.source.ns)
-    #   
-    #   # Do deep data
-    #   clf.ns.deep <- clf %>%
-    #     bind_rows(clf.seine.deep) %>%
-    #     filter(sample.type %in% catch.source.ns)
-    # 
-    #   hlf.ns.deep <- hlf %>%
-    #     ungroup() %>%
-    #     bind_rows(clf.seine.deep) %>%
-    #     filter(sample.type %in% catch.source.ns)
-    # 
-    #   lf.final.ns.deep <- lf.final %>%
-    #     bind_rows(lf.final.seine.deep) %>%
-    #     filter(sample.type %in% catch.source.ns)
-    # 
-    #   # Combine super.clusters and super.clusters.ns.deep
-    #   super.clusters.ns.deep <- bind_rows(super.clusters, super.clusters.ns.deep) %>%
-    #     filter(sample.type %in% catch.source.ns)
-    # 
-    #   super.hauls.ns.deep    <- bind_rows(super.hauls, super.clusters.ns.deep) %>%
-    #     filter(sample.type %in% catch.source.ns)
-    #   
-    #   # ggplot() +
-    #   #   geom_text(data = super.clusters.ns, aes(long, lat, label = cluster, colour = sample.type)) +
-    #   #   coord_map()
-    #   
-    #   # Save super clusters and hauls
-    #   save(super.clusters.ns, super.hauls.ns,
-    #        file = here("Output/super_clusters_hauls_ns.Rdata"))
-    #   
-    #   save(super.clusters.ns.deep, super.hauls.ns.deep,
-    #        file = here("Output/super_clusters_hauls_ns_deep.Rdata"))
-    # }
-  } else {
-    if(exists("Output/seine_summaries.Rdata"))
-      load(here("Output/seine_summaries.Rdata"))
-    if(exists("Output/cluster_length_frequency_all_seine.Rdata"))
-      load(here("Output/cluster_length_frequency_all_seine.Rdata"))
-    if(exists("Output/cluster_length_frequency_tables_seine.Rdata"))
-      load(here("Output/cluster_length_frequency_tables_seine.Rdata"))
-    if(exists("Output/super_clusters_hauls_ns.Rdata"))
-      load(here("Output/super_clusters_hauls_ns.Rdata"))
-    
-    # load(here("Output/seine_summaries_deep.Rdata"))
-    # load(here("Output/cluster_length_frequency_all_seine_deep.Rdata"))
-    # load(here("Output/cluster_length_frequency_tables_seine_deep.Rdata"))
-    # load(here("Output/super_clusters_hauls_ns_deep.Rdata"))
+    ggsave(check.deep.nasc, here("Figs/fig_check_deep_nasc.png"))
   }
   
   # Define missing variables in the trawl data
@@ -215,6 +127,24 @@ if (process.nearshore) {
   if (!"cluster" %in% names(hlf)) hlf$cluster <- as.numeric(NA)
   
   if (use.seine.data) {
+    # Process purse seine data
+    if (process.seine) {
+      # Process seine data
+      ## Need to update to handle seine data from the SWFSC database
+      source(here("Code/processSeine.R"))
+      
+    } else {
+      # Load processed seine data
+      if (exists("Output/seine_summaries.Rdata"))
+        load(here("Output/seine_summaries.Rdata"))
+      if (exists("Output/cluster_length_frequency_all_seine.Rdata"))
+        load(here("Output/cluster_length_frequency_all_seine.Rdata"))
+      if (exists("Output/cluster_length_frequency_tables_seine.Rdata"))
+        load(here("Output/cluster_length_frequency_tables_seine.Rdata"))
+      if (exists("Output/super_clusters_hauls_ns.Rdata"))
+        load(here("Output/super_clusters_hauls_ns.Rdata"))
+    }
+    
     # In 2207RL, seine data was included in the clf, so no need to combine with seine data
     # Also, this correctly applies the "adjusted" proportions of sardine and jacks in that survey
     if (survey.name == "2207RL") {
@@ -222,13 +152,7 @@ if (process.nearshore) {
       clf.seine      <- filter(clf.seine, lat <= 40.42)
       lf.final.seine <- filter(lf.final.seine, cluster %in% unique(clf.seine$cluster))
     }
-    
-    # # Define variables if missing
-    # if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
-    # if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
-    # if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
-    # if (!"cluster" %in% names(hlf))     hlf$cluster <- as.numeric(NA)
-    
+
     # Combine clf, hlf, and clf.seine 
     clf.ns <- clf %>%
       bind_rows(clf.seine) %>% 
@@ -250,40 +174,12 @@ if (process.nearshore) {
     super.clusters.ns <- bind_rows(super.clusters, super.clusters.ns) %>% 
       filter(sample.type %in% catch.source.ns)
     
-    # Do deep data
-    clf.ns.deep <- clf %>%
-      bind_rows(clf.seine.deep) %>%
-      filter(sample.type %in% catch.source.ns)
-    
-    hlf.ns.deep <- hlf %>%
-      ungroup() %>%
-      bind_rows(clf.seine.deep) %>%
-      filter(sample.type %in% catch.source.ns)
-    
-    lf.final.ns.deep <- lf.final %>%
-      bind_rows(lf.final.seine.deep) %>%
-      filter(sample.type %in% catch.source.ns)
-    
-    # Combine super.clusters and super.clusters.ns.deep
-    super.clusters.ns.deep <- bind_rows(super.clusters, super.clusters.ns.deep) %>%
-      filter(sample.type %in% catch.source.ns)
-    
-    super.hauls.ns.deep    <- bind_rows(super.hauls, super.clusters.ns.deep) %>%
-      filter(sample.type %in% catch.source.ns)
-    
-    # ggplot() +
-    #   geom_text(data = super.clusters.ns, aes(long, lat, label = cluster, colour = sample.type)) +
-    #   coord_map()
-    
     # Save super clusters and hauls
     save(super.clusters.ns, super.hauls.ns,
          file = here("Output/super_clusters_hauls_ns.Rdata"))
     
-    save(super.clusters.ns.deep, super.hauls.ns.deep,
-         file = here("Output/super_clusters_hauls_ns_deep.Rdata"))
   } else {
     # Use only trawl data to partition nearshore backscatter
-    # Combine clf, hlf, and clf.seine 
     clf.ns <- clf 
     
     hlf.ns <- hlf 
@@ -309,7 +205,7 @@ if (process.nearshore) {
   # that extend beyond the nearshore survey footprint for those surveys.
   
   # Consider adding a variable clip.nearshore.intervals to settings since this is buried in the code.
-  if (survey.name %in% c("2307RL","2407RL", "2506SH")) {
+  if (as.numeric(survey.year) >= 2023) {
     # Buffer mainland by 7 nmi, which seems to encompass the footprint of the
     # planned nearshore transects
     na_buffer_ns <- na_landmask %>% 
@@ -348,17 +244,12 @@ if (process.nearshore) {
   # Save after processing nearshore
   save(clf.ns, hlf.ns, super.clusters.ns, super.hauls.ns, lf.final.ns, 
        file = here("Output/clf_nearshore.Rdata"))
-  
-  # save(clf.ns.deep, hlf.ns.deep, super.clusters.ns.deep, super.hauls.ns.deep, lf.final.ns.deep, 
-  #      file = here("Output/clf_nearshore_deep.Rdata"))
-  
-  # Write clf.ns and clf.ns.deep to CSV
+
+  # Write clf.ns to CSV
   write_csv(clf.ns, file = here("Output/clf_nearshore.csv"))
-  # write_csv(clf.ns.deep, file = here("Output/clf_nearshore_deep.csv"))
   
   # Assign backscatter to trawl clusters ------------------------------------
   saveRDS(nasc.nearshore, here("Output/nasc_match_ns.rds"))
-  # nasc.nearshore <- readRDS(here("Output/nasc_match_ns.rds"))
   
   nasc.match.ns <- nasc.nearshore %>% 
     st_as_sf(coords = c("long","lat"), crs = crs.geog)
@@ -371,22 +262,11 @@ if (process.nearshore) {
     st_as_sf(coords = c("long","lat"), crs = crs.geog) %>% 
     filter(sample.type %in% catch.source.ns)
   
-  # cluster.match.ns.deep <- super.clusters.ns.deep %>%
-  #   st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-  #   filter(sample.type %in% catch.source.ns)
-  # 
-  # haul.match.ns.deep <- super.hauls.ns.deep %>%
-  #   st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-  #   filter(sample.type %in% catch.source.ns)
-  
   # Find nearest cluster ----------------------------
   # Returns a vector of nearest clusters
   nearest.cluster.ns <- st_nearest_feature(nasc.match.ns, cluster.match.ns)
   nearest.haul.ns    <- st_nearest_feature(nasc.match.ns, haul.match.ns)
-  
-  # nearest.cluster.ns.deep <- st_nearest_feature(nasc.match.ns, cluster.match.ns.deep)
-  # nearest.haul.ns.deep <- st_nearest_feature(nasc.match.ns, haul.match.ns.deep)
-  
+
   # Expand clf to match nasc ------------------------
   cluster.ns.sp <- cluster.match.ns[nearest.cluster.ns, ] %>% 
     select(geometry) %>% 
@@ -395,14 +275,6 @@ if (process.nearshore) {
   haul.ns.sp <- haul.match.ns[nearest.haul.ns, ] %>% 
     select(geometry) %>% 
     as_Spatial()
-  
-  # cluster.ns.sp.deep <- cluster.match.ns.deep[nearest.cluster.ns.deep, ] %>%
-  #   select(geometry) %>%
-  #   as_Spatial()
-  # 
-  # haul.ns.sp.deep <- haul.match.ns.deep[nearest.haul.ns.deep, ] %>%
-  #   select(geometry) %>%
-  #   as_Spatial()
   
   # Make nasc sp
   # Removing the other data (i.e., only retaining the geometry) decreases the size of nasc from 50 to 1 MB
@@ -418,14 +290,6 @@ if (process.nearshore) {
            haul = haul.match.ns$haul[nearest.haul.ns],
            haul.distance = distGeo(nasc.ns.sp, haul.ns.sp)*0.000539957)  
   
-  if (exists("cluster.match.ns.deep")) {
-    nasc.match.ns <- nasc.match.ns %>% 
-      mutate(cluster.deep = cluster.match.ns.deep$cluster[nearest.cluster.ns.deep],
-             cluster.distance.deep = distGeo(nasc.ns.sp, cluster.ns.sp.deep)*0.000539957,
-             haul.deep = haul.match.ns.deep$haul[nearest.haul.ns.deep],
-             haul.distance.deep = distGeo(nasc.ns.sp, haul.ns.sp.deep)*0.000539957)
-  }
-  
   # Remove geometry
   nasc.match.ns <- st_set_geometry(nasc.match.ns, NULL) 
   
@@ -433,31 +297,23 @@ if (process.nearshore) {
   nasc.nearshore <- nasc.nearshore %>% 
     bind_cols(select(nasc.match.ns, cluster, cluster.distance, haul, haul.distance))  
   
-  if (exists("cluster.match.ns.deep")) {
-    # Add deep nasc clusters and cluster distances to nasc
-    nasc.nearshore <- nasc.nearshore %>% 
-      bind_cols(select(nasc.match.ns, cluster.deep, cluster.distance.deep, haul.deep, haul.distance.deep))
-  }
-  
-  # ggplot(nasc.nearshore, aes(long, lat, colour = factor(cluster))) + geom_point() + coord_map()
-  
-  # ggplot(nasc.nearshore, aes(long, lat, colour = factor(cluster))) +
-  #   geom_point(show.legend = FALSE) +
-  #   geom_text(data = super.clusters.ns, 
-  #             aes(long, lat, label = factor(cluster),
-  #                 colour = factor(cluster)), show.legend = FALSE) +
-  #   coord_map()
+  nasc.cluster.ns.plot <- ggplot(nasc.nearshore, aes(long, lat, colour = factor(cluster))) +
+    geom_point(show.legend = FALSE) +
+    geom_text(data = super.clusters.ns,
+              aes(long, lat, label = factor(cluster),
+                  colour = factor(cluster)), show.legend = FALSE) +
+    coord_map()
   
   # Save results of processing
   save(nasc.nearshore, file = here("Data/Backscatter/nasc_nearshore.Rdata"))
   
 } else {
   # Load processed data
-  # load(here("Data/Backscatter/nasc_nearshore.Rdata"))
-  # load(here("Output/clf_nearshore.Rdata"))
-  # load(here("Output/seine_summaries.Rdata"))
-  # load(here("Output/clf_nearshore_deep.Rdata"))
-  # load(here("Output/seine_summaries_deep.Rdata"))
+  load(here("Data/Backscatter/nasc_nearshore.Rdata"))
+  if (file.exists(here("Output/clf_nearshore.Rdata")))
+    load(here("Output/clf_nearshore.Rdata"))
+  if (file.exists(here("Output/seine_summaries.Rdata")))
+    load(here("Output/seine_summaries.Rdata"))
 }
 
 # For 2307RL (and perhaps beyond), deep backscatter observed by nearshore vessels are probably
@@ -520,20 +376,6 @@ nasc.super.hauls.ns <- nasc.nearshore %>%
   summarise() %>% 
   st_convex_hull()
 
-if ("cluster.deep" %in% names(nasc.nearshore)) {
-  nasc.super.clusters.ns.deep <- nasc.nearshore %>%
-    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-    group_by(cluster.deep) %>%
-    summarise() %>%
-    st_convex_hull()
-  
-  nasc.super.hauls.ns.deep <- nasc.nearshore %>%
-    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-    group_by(haul.deep) %>%
-    summarise() %>%
-    st_convex_hull()
-}
-
 if (save.figs) {
   nasc.cluster.plot.ns <- base.map +
     # Plot nasc data
@@ -587,64 +429,6 @@ if (save.figs) {
   save(nasc.cluster.plot.ns, nasc.haul.plot.ns, file = here("Output/nasc_cluster_plot_ns.Rdata"))
 }
 
-if (save.figs) {
-  if (exists("clf.ns.deep")) {
-    nasc.cluster.plot.ns.deep <- base.map +
-      # Plot nasc data
-      geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
-      # Plot convex hull around NASC clusters
-      geom_sf(data = nasc.super.clusters.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
-      scale_fill_discrete(name = "Cluster") +
-      scale_colour_manual(name = "Cluster", values = c("Trawl" = "blue", "Purse seine" = "red")) +
-      # Plot cluster midpoints
-      geom_shadowtext(data = filter(clf.ns.deep, CPS.num == 0),
-                      aes(X, Y, label = cluster),
-                      colour = 'gray20', bg.colour = "white", size = 2) +
-      # Plot positive trawl cluster midpoints
-      geom_shadowtext(data = filter(clf.ns.deep, CPS.num > 0, cluster %in% nasc.nearshore$cluster.deep),
-                      aes(X, Y, label = cluster, colour = sample.type),
-                      size = 2, bg.colour = "white", fontface = "bold") +
-      # Plot panel label
-      coord_sf(crs = crs.proj,
-               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-    
-    nasc.haul.plot.ns.deep <- base.map +
-      # Plot nasc data
-      geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
-      # Plot convex hull around NASC clusters
-      geom_sf(data = nasc.super.hauls.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
-      scale_fill_discrete(name = "Haul") +
-      scale_colour_manual(name = "Haul", values = c("Trawl" = "blue", "Purse seine" = "red")) +
-      # Plot cluster midpoints
-      geom_shadowtext(data = filter(hlf.ns.deep, CPS.num == 0),
-                      aes(X, Y, label = haul),
-                      colour = 'gray20', bg.colour = "white", size = 2) +
-      # Plot positive trawl cluster midpoints
-      geom_shadowtext(data = filter(hlf.ns.deep, CPS.num > 0, haul %in% nasc.nearshore$haul.deep),
-                      aes(X, Y, label = haul, colour = sample.type),
-                      size = 2, bg.colour = "white", fontface = "bold") +
-      # Plot panel label
-      coord_sf(crs = crs.proj,
-               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-    
-    ## Map polygons to explore NA values
-    # mapview(nasc.super.hauls.ns.deep)
-    
-    # save trawl plot
-    ggsave(nasc.cluster.plot.ns.deep,
-           filename = here("Figs/fig_nasc_cluster_map_ns_deep.png"),
-           width = map.width, height = map.height)
-    
-    ggsave(nasc.haul.plot.ns.deep,
-           filename = here("Figs/fig_nasc_haul_map_ns_deep.png"),
-           width = map.width, height = map.height)
-    
-    save(nasc.cluster.plot.ns.deep, file = here("Output/nasc_cluster_plot_ns_deep.Rdata"))
-  }
-}
-
 # Map nearshore species proportions -------------------------------------------------------
 if (use.seine.data) {
   # Combine pie chart data from trawls and seines
@@ -653,14 +437,6 @@ if (use.seine.data) {
   haul.pie <- set.pie %>% 
     select(-cluster) %>% 
     bind_rows(haul.pie)
-  
-  if (exists("set.pie.deep")) {
-    cluster.pie.deep <- bind_rows(cluster.pie, set.pie.deep)
-    
-    haul.pie.deep <- set.pie.deep %>%
-      select(-cluster) %>%
-      bind_rows(haul.pie)  
-  }
   
   # ggplot() +
   #   geom_text(data = cluster.pie, aes(long, lat, label = cluster, colour = sample.type), show.legend = FALSE) +
@@ -699,38 +475,6 @@ if (nrow(haul.pos.ns) > 0) {
 cluster.zero.ns <- filter(cluster.pie.ns, AllCPS == 0)
 haul.zero.ns    <- filter(haul.pie.ns, AllCPS == 0)
 
-if (exists("cluster.pie.deep")) {
-  # Do deep data
-  cluster.pie.ns.deep <- cluster.pie.deep %>%
-    filter(cluster %in% unique(nasc.nearshore$cluster.deep),
-           sample.type %in% catch.source.ns)
-  
-  cluster.pos.ns.deep <- filter(cluster.pie.ns.deep, AllCPS > 0) %>%
-    arrange(desc(X))
-  
-  # Select only hauls assigned to nasc intervals and included in catch.source.ns
-  haul.pie.ns.deep <- haul.pie.deep %>%
-    filter(haul %in% unique(nasc.nearshore$haul.deep),
-           sample.type %in% catch.source.ns)
-  
-  haul.pos.ns.deep <- filter(haul.pie.ns.deep, AllCPS > 0) %>%
-    arrange(desc(X))  
-  
-  if (nrow(cluster.pos.ns.deep) > 0) {
-    cluster.pos.ns.deep <- cluster.pos.ns.deep %>%
-      replace(. == 0, 0.0000001)
-  }
-  
-  if (nrow(haul.pos.ns.deep) > 0) {
-    haul.pos.ns.deep <- haul.pos.ns.deep %>%
-      replace(. == 0, 0.0000001)
-  }
-  
-  # Filter for empty trawls
-  cluster.zero.ns.deep <- filter(cluster.pie.ns.deep, AllCPS == 0)
-  haul.zero.ns.deep    <- filter(haul.pie.ns.deep, AllCPS == 0)
-}
-
 ## NOTE: These plots show proportion of catch by weight, NOT acoustic proportion
 ## The acoustic proportions get plotted below
 ## AFAIK, these figures are exploratory only, and do not appear in any reports
@@ -766,28 +510,13 @@ if (cluster.source["NS"] == "cluster") {
   nasc.nearshore <- nasc.nearshore.tmp %>% 
     left_join(select(clf.ns, -lat, -long, -X, -Y), by = c("cluster" = "cluster"))
   # left_join(select(clf.ns, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
-  
-  if (exists("clf.ns.deep"))
-    nasc.nearshore.deep <- nasc.nearshore.tmp %>%
-      left_join(select(clf.ns.deep, -lat, -long, -X, -Y), by = c("cluster" = "cluster"))
-  # left_join(select(clf.ns.deep, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
-  
 } else {
   nasc.nearshore <- nasc.nearshore.tmp %>% 
     left_join(select(hlf.ns, -lat, -long, -X, -Y,-cluster), by = c("haul" = "haul"))
-  
-  if (exists("hlf.ns.deep"))
-    nasc.nearshore.deep <- nasc.nearshore.tmp %>%
-      left_join(select(hlf.ns.deep, -lat, -long, -X, -Y,-cluster), by = c("haul" = "haul"))
 }
 
 # Save results
 save(nasc.nearshore, file = here("Output/cps_nasc_prop_ns.Rdata"))
-
-if(exists("nasc.nearshore.deep")) {
-  save(nasc.nearshore.deep, file = here("Output/cps_nasc_prop_ns_deep.Rdata"))  
-}
-
 
 # Summarize transects -----------------------------------------------------
 # Summarize nasc data
@@ -817,12 +546,6 @@ if (limit.cluster.dist["NS"]) {
   nasc.nearshore$prop.jack[nasc.nearshore$cluster.distance > max.cluster.dist] <- 0
   nasc.nearshore$prop.mack[nasc.nearshore$cluster.distance > max.cluster.dist] <- 0
   nasc.nearshore$prop.her[nasc.nearshore$cluster.distance  > max.cluster.dist] <- 0  
-  
-  nasc.nearshore.deep$prop.anch[nasc.nearshore.deep$cluster.distance.deep > max.cluster.dist] <- 0
-  nasc.nearshore.deep$prop.sar[nasc.nearshore.deep$cluster.distance.deep  > max.cluster.dist] <- 0
-  nasc.nearshore.deep$prop.jack[nasc.nearshore.deep$cluster.distance.deep > max.cluster.dist] <- 0
-  nasc.nearshore.deep$prop.mack[nasc.nearshore.deep$cluster.distance.deep > max.cluster.dist] <- 0
-  nasc.nearshore.deep$prop.her[nasc.nearshore.deep$cluster.distance.deep  > max.cluster.dist] <- 0
 }
 
 # Create data frame for plotting acoustic proportions by species
@@ -835,29 +558,11 @@ nasc.prop.all.ns <- nasc.nearshore %>%
          `Clupea pallasii`       = cps.nasc*prop.her,
          `Etrumeus acuminatus`   = cps.nasc*prop.rher) 
 
-if(exists("nasc.nearshore.deep")) {
-  # For intervals with deep backscatter
-  nasc.prop.all.ns.deep <- nasc.nearshore.deep %>%
-    mutate(`Engraulis mordax`      = cps.nasc.deep*prop.anch,
-           `Sardinops sagax`       = cps.nasc.deep*prop.sar,
-           `Trachurus symmetricus` = cps.nasc.deep*prop.jack,
-           `Scomber japonicus`     = cps.nasc.deep*prop.mack,
-           `Clupea pallasii`       = cps.nasc.deep*prop.her,
-           `Etrumeus acuminatus`   = cps.nasc.deep*prop.rher)
-}
-
 # Prepare nasc.prop.all for facet plotting
 nasc.prop.spp.ns <- nasc.prop.all.ns %>% 
   select(X, Y, `Engraulis mordax`, `Sardinops sagax`, `Trachurus symmetricus`,
          `Scomber japonicus`, `Clupea pallasii`, `Etrumeus acuminatus`) %>% 
   gather(scientificName, nasc, -X, -Y)
-
-if(exists("nasc.prop.spp.ns.deep")) {
-  nasc.prop.spp.ns.deep <- nasc.prop.all.ns.deep %>%
-    select(X, Y, `Engraulis mordax`, `Sardinops sagax`, `Trachurus symmetricus`,
-           `Scomber japonicus`, `Clupea pallasii`, `Etrumeus acuminatus`) %>%
-    gather(scientificName, nasc, -X, -Y)
-}
 
 if (save.figs) {
   # Create a base map with relative CPS backscatter
@@ -883,34 +588,10 @@ if (save.figs) {
   # Save plot objects
   save(map.prop.all.ns, file = here("Output/acoustic_proportion_maps_ns.Rdata"))
   
-  if(exists("nasc.prop.spp.ns.deep")) {
-    map.prop.all.ns.deep <- base.map +
-      # Plot backscatter for all CPS nasc
-      geom_point(data = nasc.prop.all.ns.deep, aes(X, Y, size = cps.nasc.deep),
-                 colour = "gray20") +
-      # Plot proportion of backscatter from each species present
-      geom_point(data = filter(nasc.prop.spp.ns.deep, nasc > 0),
-                 aes(X, Y, size = nasc), colour = "red") +
-      # Facet by species
-      facet_wrap(~scientificName, nrow = 2) +
-      theme(strip.background.x = element_blank(),
-            strip.text.x       = element_text(face = "italic")) +
-      coord_sf(crs = crs.proj,
-               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-    
-    ggsave(here("Figs/fig_nasc_acoustic_proportions_ns_deep.png"), map.prop.all.ns.deep,
-           width = map.width*3, height = map.height*2)
-    
-    save(map.prop.all.ns.deep, file = here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
-  }
-  
 } else {
   # Load plot objects
   load(here("Output/acoustic_proportion_maps_ns.Rdata"))
-  
-  if(exists(here("Output/acoustic_proportion_maps_ns_deep.Rdata")))
-    load(here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
+
 }
 
 # Calculate nearshore acoustic biomass density -----------------------------
@@ -924,18 +605,6 @@ nasc.nearshore <- nasc.nearshore %>%
     sar.dens  = cps.nasc*prop.sar  / (4*pi*sigmawg.sar)  / 1000,
     rher.dens = cps.nasc*prop.rher / (4*pi*sigmawg.rher) / 1000)
 
-# Deep density
-if(exists("nasc.nearshore.deep")) {
-  nasc.nearshore.deep <- nasc.nearshore.deep %>%
-    mutate(
-      anch.dens = cps.nasc.deep*prop.anch / (4*pi*sigmawg.anch) / 1000,
-      her.dens  = cps.nasc.deep*prop.her  / (4*pi*sigmawg.her)  / 1000,
-      jack.dens = cps.nasc.deep*prop.jack / (4*pi*sigmawg.jack) / 1000,
-      mack.dens = cps.nasc.deep*prop.mack / (4*pi*sigmawg.mack) / 1000,
-      sar.dens  = cps.nasc.deep*prop.sar  / (4*pi*sigmawg.sar)  / 1000,
-      rher.dens = cps.nasc.deep*prop.rher / (4*pi*sigmawg.rher) / 1000)
-}
-
 # Add deep density to shallow density
 # This is where the magic happens, I think.
 if (adj.deep.nasc) {
@@ -947,6 +616,8 @@ if (adj.deep.nasc) {
            sar.dens  = sar.dens  + nasc.nearshore.deep$sar.dens,
            rher.dens = rher.dens + nasc.nearshore.deep$rher.dens)  
 }
+
+# RESUME HERE ----------------------------------
 
 # Format for plotting
 nasc.density.ns <- nasc.nearshore %>%
@@ -2071,8 +1742,8 @@ strata.final.ns <- strata.final.ns %>%
 saveRDS(strata.final.ns, file = here("Output/strata_final_ns.rds"))
 
 # Remove point estimates, if they exist
-if(exists("point.estimates.ns")) rm(point.estimates.ns)
-# if(exists("point.estimates.ns.deep")) rm(point.estimates.ns.deep)
+if (exists("point.estimates.ns")) rm(point.estimates.ns)
+# if (exists("point.estimates.ns.deep")) rm(point.estimates.ns.deep)
 
 # Calculate point estimates for each species
 for (i in unique(strata.final.ns$scientificName)) {
@@ -2092,7 +1763,7 @@ for (i in unique(strata.final.ns$scientificName)) {
       # ggplot(nasc.ns.temp, aes(long, lat, size = cps.nasc, colour = factor(stratum))) + geom_point() + coord_map()
       
       # Subset deep NASC
-      if(adj.deep.nasc) {
+      if (adj.deep.nasc) {
         nasc.ns.temp.deep <- nasc.nearshore.deep %>%
           select(-stratum) %>%
           left_join(strata.temp) %>%
@@ -2131,7 +1802,7 @@ for (i in unique(strata.final.ns$scientificName)) {
         point.estimates.ns <- bind_rows(point.estimates.ns,
                                         data.frame(scientificName = i, vessel.name = j,
                                                    estimate_point(nasc.ns.temp, stratum.info.nearshore, species = i)))
-        if(adj.deep.nasc) {
+        if (adj.deep.nasc) {
           # Calculate deep point estimates
           point.estimates.ns.deep <- bind_rows(point.estimates.ns.deep,
                                                data.frame(scientificName = i, vessel.name = j,
@@ -2141,7 +1812,7 @@ for (i in unique(strata.final.ns$scientificName)) {
       } else {
         point.estimates.ns <- data.frame(scientificName = i, vessel.name = j,
                                          estimate_point(nasc.ns.temp, stratum.info.nearshore, species = i))
-        if(adj.deep.nasc) {
+        if (adj.deep.nasc) {
           # Calculate deep point estimates
           point.estimates.ns.deep <- data.frame(scientificName = i, vessel.name = j,
                                                 estimate_point(nasc.ns.temp.deep, stratum.info.nearshore, species = i))  
@@ -2152,7 +1823,7 @@ for (i in unique(strata.final.ns$scientificName)) {
 }
 
 # Combine deep and shallow results
-if(adj.deep.nasc) {
+if (adj.deep.nasc) {
   point.estimates.ns <- point.estimates.ns %>%
     left_join(select(point.estimates.ns.deep, -area, biomass.deep = biomass.total)) %>%
     mutate(biomass.corr = biomass.total + biomass.deep)  

--- a/Code/estimateNearshore.R
+++ b/Code/estimateNearshore.R
@@ -115,7 +115,7 @@ if (process.nearshore) {
       mutate(cps.nasc = case_when(
         cps.nasc.deep >= cps.nasc & vessel.orig %in% deep.nasc.vessels ~ cps.nasc.deep - cps.nasc,
         TRUE ~ cps.nasc))
-
+    
     # ggplot(nasc.nearshore, aes(cps.nasc, NASC.20)) + geom_point(aes(colour = vessel.orig)) + geom_abline(slope = 1, intercept = 0) + facet_wrap(~vessel.orig)
     # ggplot(nasc.nearshore, aes(cps.nasc, cps.nasc.deep)) + geom_abline(slope = 1, intercept = 0) + geom_point(aes(colour = vessel.orig)) + facet_wrap(~vessel.orig)
   }
@@ -124,84 +124,180 @@ if (process.nearshore) {
   if (process.seine) {
     source(here("Code/processSeine.R"))
     
-    if (use.seine.data) {
-      # In 2207RL, seine data was included in the clf, so no need to combine with seine data
-      # Also, this correctly applies the "adjusted" proportions of sardine and jacks in that survey
-      if (survey.name == "2207RL") {
-        # Remove LM sets north of Cape Mendocino
-        clf.seine      <- filter(clf.seine, lat <= 40.42)
-        lf.final.seine <- filter(lf.final.seine, cluster %in% unique(clf.seine$cluster))
-      }
-      
-      # Define variables if missing
-      if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
-      if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
-      if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
-      if (!"cluster" %in% names(hlf))     hlf$cluster <- as.numeric(NA)
-      
-      # Combine clf, hlf, and clf.seine 
-      clf.ns <- clf %>%
-        bind_rows(clf.seine) %>% 
-        filter(sample.type %in% catch.source.ns)
-      
-      hlf.ns <- hlf %>% 
-        ungroup() %>% 
-        bind_rows(clf.seine) %>% 
-        filter(sample.type %in% catch.source.ns)  
-      
-      lf.final.ns <- lf.final %>% 
-        bind_rows(lf.final.seine) %>% 
-        filter(sample.type %in% catch.source.ns)
-      
-      # Combine super clusters from the core and nearshore regions
-      super.hauls.ns    <- bind_rows(super.hauls, super.clusters.ns) %>% 
-        filter(sample.type %in% catch.source.ns)
-      
-      super.clusters.ns <- bind_rows(super.clusters, super.clusters.ns) %>% 
-        filter(sample.type %in% catch.source.ns)
-      
-      # Do deep data
-      clf.ns.deep <- clf %>%
-        bind_rows(clf.seine.deep) %>%
-        filter(sample.type %in% catch.source.ns)
-
-      hlf.ns.deep <- hlf %>%
-        ungroup() %>%
-        bind_rows(clf.seine.deep) %>%
-        filter(sample.type %in% catch.source.ns)
-
-      lf.final.ns.deep <- lf.final %>%
-        bind_rows(lf.final.seine.deep) %>%
-        filter(sample.type %in% catch.source.ns)
-
-      # Combine super.clusters and super.clusters.ns.deep
-      super.clusters.ns.deep <- bind_rows(super.clusters, super.clusters.ns.deep) %>%
-        filter(sample.type %in% catch.source.ns)
-
-      super.hauls.ns.deep    <- bind_rows(super.hauls, super.clusters.ns.deep) %>%
-        filter(sample.type %in% catch.source.ns)
-      
-      # ggplot() +
-      #   geom_text(data = super.clusters.ns, aes(long, lat, label = cluster, colour = sample.type)) +
-      #   coord_map()
-      
-      # Save super clusters and hauls
-      save(super.clusters.ns, super.hauls.ns,
-           file = here("Output/super_clusters_hauls_ns.Rdata"))
-      
-      save(super.clusters.ns.deep, super.hauls.ns.deep,
-           file = here("Output/super_clusters_hauls_ns_deep.Rdata"))
-    }
+    # if (use.seine.data) {
+    #   # In 2207RL, seine data was included in the clf, so no need to combine with seine data
+    #   # Also, this correctly applies the "adjusted" proportions of sardine and jacks in that survey
+    #   if (survey.name == "2207RL") {
+    #     # Remove LM sets north of Cape Mendocino
+    #     clf.seine      <- filter(clf.seine, lat <= 40.42)
+    #     lf.final.seine <- filter(lf.final.seine, cluster %in% unique(clf.seine$cluster))
+    #   }
+    #   
+    #   # Define variables if missing
+    #   if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
+    #   if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
+    #   if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
+    #   if (!"cluster" %in% names(hlf))     hlf$cluster <- as.numeric(NA)
+    #   
+    #   # Combine clf, hlf, and clf.seine 
+    #   clf.ns <- clf %>%
+    #     bind_rows(clf.seine) %>% 
+    #     filter(sample.type %in% catch.source.ns)
+    #   
+    #   hlf.ns <- hlf %>% 
+    #     ungroup() %>% 
+    #     bind_rows(clf.seine) %>% 
+    #     filter(sample.type %in% catch.source.ns)  
+    #   
+    #   lf.final.ns <- lf.final %>% 
+    #     bind_rows(lf.final.seine) %>% 
+    #     filter(sample.type %in% catch.source.ns)
+    #   
+    #   # Combine super clusters from the core and nearshore regions
+    #   super.hauls.ns    <- bind_rows(super.hauls, super.clusters.ns) %>% 
+    #     filter(sample.type %in% catch.source.ns)
+    #   
+    #   super.clusters.ns <- bind_rows(super.clusters, super.clusters.ns) %>% 
+    #     filter(sample.type %in% catch.source.ns)
+    #   
+    #   # Do deep data
+    #   clf.ns.deep <- clf %>%
+    #     bind_rows(clf.seine.deep) %>%
+    #     filter(sample.type %in% catch.source.ns)
+    # 
+    #   hlf.ns.deep <- hlf %>%
+    #     ungroup() %>%
+    #     bind_rows(clf.seine.deep) %>%
+    #     filter(sample.type %in% catch.source.ns)
+    # 
+    #   lf.final.ns.deep <- lf.final %>%
+    #     bind_rows(lf.final.seine.deep) %>%
+    #     filter(sample.type %in% catch.source.ns)
+    # 
+    #   # Combine super.clusters and super.clusters.ns.deep
+    #   super.clusters.ns.deep <- bind_rows(super.clusters, super.clusters.ns.deep) %>%
+    #     filter(sample.type %in% catch.source.ns)
+    # 
+    #   super.hauls.ns.deep    <- bind_rows(super.hauls, super.clusters.ns.deep) %>%
+    #     filter(sample.type %in% catch.source.ns)
+    #   
+    #   # ggplot() +
+    #   #   geom_text(data = super.clusters.ns, aes(long, lat, label = cluster, colour = sample.type)) +
+    #   #   coord_map()
+    #   
+    #   # Save super clusters and hauls
+    #   save(super.clusters.ns, super.hauls.ns,
+    #        file = here("Output/super_clusters_hauls_ns.Rdata"))
+    #   
+    #   save(super.clusters.ns.deep, super.hauls.ns.deep,
+    #        file = here("Output/super_clusters_hauls_ns_deep.Rdata"))
+    # }
   } else {
-    load(here("Output/seine_summaries.Rdata"))
-    load(here("Output/cluster_length_frequency_all_seine.Rdata"))
-    load(here("Output/cluster_length_frequency_tables_seine.Rdata"))
-    load(here("Output/super_clusters_hauls_ns.Rdata"))
-
-    load(here("Output/seine_summaries_deep.Rdata"))
-    load(here("Output/cluster_length_frequency_all_seine_deep.Rdata"))
-    load(here("Output/cluster_length_frequency_tables_seine_deep.Rdata"))
-    load(here("Output/super_clusters_hauls_ns_deep.Rdata"))
+    if(exists("Output/seine_summaries.Rdata"))
+      load(here("Output/seine_summaries.Rdata"))
+    if(exists("Output/cluster_length_frequency_all_seine.Rdata"))
+      load(here("Output/cluster_length_frequency_all_seine.Rdata"))
+    if(exists("Output/cluster_length_frequency_tables_seine.Rdata"))
+      load(here("Output/cluster_length_frequency_tables_seine.Rdata"))
+    if(exists("Output/super_clusters_hauls_ns.Rdata"))
+      load(here("Output/super_clusters_hauls_ns.Rdata"))
+    
+    # load(here("Output/seine_summaries_deep.Rdata"))
+    # load(here("Output/cluster_length_frequency_all_seine_deep.Rdata"))
+    # load(here("Output/cluster_length_frequency_tables_seine_deep.Rdata"))
+    # load(here("Output/super_clusters_hauls_ns_deep.Rdata"))
+  }
+  
+  # Define missing variables in the trawl data
+  if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
+  if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
+  if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
+  if (!"cluster" %in% names(hlf)) hlf$cluster <- as.numeric(NA)
+  
+  if (use.seine.data) {
+    # In 2207RL, seine data was included in the clf, so no need to combine with seine data
+    # Also, this correctly applies the "adjusted" proportions of sardine and jacks in that survey
+    if (survey.name == "2207RL") {
+      # Remove LM sets north of Cape Mendocino
+      clf.seine      <- filter(clf.seine, lat <= 40.42)
+      lf.final.seine <- filter(lf.final.seine, cluster %in% unique(clf.seine$cluster))
+    }
+    
+    # # Define variables if missing
+    # if (!"sample.type" %in% names(clf)) clf$sample.type <- "Trawl"
+    # if (!"sample.type" %in% names(hlf)) hlf$sample.type <- "Trawl"
+    # if (!"sample.type" %in% names(lf.final)) lf.final$sample.type <- "Trawl"
+    # if (!"cluster" %in% names(hlf))     hlf$cluster <- as.numeric(NA)
+    
+    # Combine clf, hlf, and clf.seine 
+    clf.ns <- clf %>%
+      bind_rows(clf.seine) %>% 
+      filter(sample.type %in% catch.source.ns)
+    
+    hlf.ns <- hlf %>% 
+      ungroup() %>% 
+      bind_rows(clf.seine) %>% 
+      filter(sample.type %in% catch.source.ns)  
+    
+    lf.final.ns <- lf.final %>% 
+      bind_rows(lf.final.seine) %>% 
+      filter(sample.type %in% catch.source.ns)
+    
+    # Combine super clusters from the core and nearshore regions
+    super.hauls.ns    <- bind_rows(super.hauls, super.clusters.ns) %>% 
+      filter(sample.type %in% catch.source.ns)
+    
+    super.clusters.ns <- bind_rows(super.clusters, super.clusters.ns) %>% 
+      filter(sample.type %in% catch.source.ns)
+    
+    # Do deep data
+    clf.ns.deep <- clf %>%
+      bind_rows(clf.seine.deep) %>%
+      filter(sample.type %in% catch.source.ns)
+    
+    hlf.ns.deep <- hlf %>%
+      ungroup() %>%
+      bind_rows(clf.seine.deep) %>%
+      filter(sample.type %in% catch.source.ns)
+    
+    lf.final.ns.deep <- lf.final %>%
+      bind_rows(lf.final.seine.deep) %>%
+      filter(sample.type %in% catch.source.ns)
+    
+    # Combine super.clusters and super.clusters.ns.deep
+    super.clusters.ns.deep <- bind_rows(super.clusters, super.clusters.ns.deep) %>%
+      filter(sample.type %in% catch.source.ns)
+    
+    super.hauls.ns.deep    <- bind_rows(super.hauls, super.clusters.ns.deep) %>%
+      filter(sample.type %in% catch.source.ns)
+    
+    # ggplot() +
+    #   geom_text(data = super.clusters.ns, aes(long, lat, label = cluster, colour = sample.type)) +
+    #   coord_map()
+    
+    # Save super clusters and hauls
+    save(super.clusters.ns, super.hauls.ns,
+         file = here("Output/super_clusters_hauls_ns.Rdata"))
+    
+    save(super.clusters.ns.deep, super.hauls.ns.deep,
+         file = here("Output/super_clusters_hauls_ns_deep.Rdata"))
+  } else {
+    # Use only trawl data to partition nearshore backscatter
+    # Combine clf, hlf, and clf.seine 
+    clf.ns <- clf 
+    
+    hlf.ns <- hlf 
+    
+    lf.final.ns <- lf.final 
+    
+    # Combine super clusters from the core and nearshore regions
+    super.hauls.ns    <- super.hauls
+    
+    super.clusters.ns <- super.clusters
+    
+    # Save super clusters and hauls
+    save(super.clusters.ns, super.hauls.ns,
+         file = here("Output/super_clusters_hauls_ns.Rdata"))
   }
   
   # Convert nearshore backscatter to sf 
@@ -213,7 +309,7 @@ if (process.nearshore) {
   # that extend beyond the nearshore survey footprint for those surveys.
   
   # Consider adding a variable clip.nearshore.intervals to settings since this is buried in the code.
-  if (survey.name %in% c("2307RL","2407RL")) {
+  if (survey.name %in% c("2307RL","2407RL", "2506SH")) {
     # Buffer mainland by 7 nmi, which seems to encompass the footprint of the
     # planned nearshore transects
     na_buffer_ns <- na_landmask %>% 
@@ -232,7 +328,7 @@ if (process.nearshore) {
     
     # Combine land masks
     nearshore_mask <- st_union(na_buffer_ns, ci_buffer)
-
+    
     # mapview(nearshore_mask) +
     #   mapview(nasc.nearshore.sf) +
     #   mapview(filter(transects.sf, Type == "Nearshore"), color = "red")
@@ -250,15 +346,15 @@ if (process.nearshore) {
   }
   
   # Save after processing nearshore
-  save(clf.ns, hlf.ns, super.clusters.ns, super.hauls.ns, lf.final.ns, set.pie, 
+  save(clf.ns, hlf.ns, super.clusters.ns, super.hauls.ns, lf.final.ns, 
        file = here("Output/clf_nearshore.Rdata"))
   
-  save(clf.ns.deep, hlf.ns.deep, super.clusters.ns.deep, super.hauls.ns.deep, lf.final.ns.deep, set.pie.deep,
-       file = here("Output/clf_nearshore_deep.Rdata"))
+  # save(clf.ns.deep, hlf.ns.deep, super.clusters.ns.deep, super.hauls.ns.deep, lf.final.ns.deep, 
+  #      file = here("Output/clf_nearshore_deep.Rdata"))
   
   # Write clf.ns and clf.ns.deep to CSV
   write_csv(clf.ns, file = here("Output/clf_nearshore.csv"))
-  write_csv(clf.ns.deep, file = here("Output/clf_nearshore_deep.csv"))
+  # write_csv(clf.ns.deep, file = here("Output/clf_nearshore_deep.csv"))
   
   # Assign backscatter to trawl clusters ------------------------------------
   saveRDS(nasc.nearshore, here("Output/nasc_match_ns.rds"))
@@ -275,21 +371,21 @@ if (process.nearshore) {
     st_as_sf(coords = c("long","lat"), crs = crs.geog) %>% 
     filter(sample.type %in% catch.source.ns)
   
-  cluster.match.ns.deep <- super.clusters.ns.deep %>%
-    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-    filter(sample.type %in% catch.source.ns)
-
-  haul.match.ns.deep <- super.hauls.ns.deep %>%
-    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-    filter(sample.type %in% catch.source.ns)
+  # cluster.match.ns.deep <- super.clusters.ns.deep %>%
+  #   st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
+  #   filter(sample.type %in% catch.source.ns)
+  # 
+  # haul.match.ns.deep <- super.hauls.ns.deep %>%
+  #   st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
+  #   filter(sample.type %in% catch.source.ns)
   
   # Find nearest cluster ----------------------------
   # Returns a vector of nearest clusters
   nearest.cluster.ns <- st_nearest_feature(nasc.match.ns, cluster.match.ns)
-  nearest.haul.ns <- st_nearest_feature(nasc.match.ns, haul.match.ns)
+  nearest.haul.ns    <- st_nearest_feature(nasc.match.ns, haul.match.ns)
   
-  nearest.cluster.ns.deep <- st_nearest_feature(nasc.match.ns, cluster.match.ns.deep)
-  nearest.haul.ns.deep <- st_nearest_feature(nasc.match.ns, haul.match.ns.deep)
+  # nearest.cluster.ns.deep <- st_nearest_feature(nasc.match.ns, cluster.match.ns.deep)
+  # nearest.haul.ns.deep <- st_nearest_feature(nasc.match.ns, haul.match.ns.deep)
   
   # Expand clf to match nasc ------------------------
   cluster.ns.sp <- cluster.match.ns[nearest.cluster.ns, ] %>% 
@@ -300,13 +396,13 @@ if (process.nearshore) {
     select(geometry) %>% 
     as_Spatial()
   
-  cluster.ns.sp.deep <- cluster.match.ns.deep[nearest.cluster.ns.deep, ] %>%
-    select(geometry) %>%
-    as_Spatial()
-
-  haul.ns.sp.deep <- haul.match.ns.deep[nearest.haul.ns.deep, ] %>%
-    select(geometry) %>%
-    as_Spatial()
+  # cluster.ns.sp.deep <- cluster.match.ns.deep[nearest.cluster.ns.deep, ] %>%
+  #   select(geometry) %>%
+  #   as_Spatial()
+  # 
+  # haul.ns.sp.deep <- haul.match.ns.deep[nearest.haul.ns.deep, ] %>%
+  #   select(geometry) %>%
+  #   as_Spatial()
   
   # Make nasc sp
   # Removing the other data (i.e., only retaining the geometry) decreases the size of nasc from 50 to 1 MB
@@ -320,36 +416,46 @@ if (process.nearshore) {
     mutate(cluster = cluster.match.ns$cluster[nearest.cluster.ns],
            cluster.distance = distGeo(nasc.ns.sp, cluster.ns.sp)*0.000539957,
            haul = haul.match.ns$haul[nearest.haul.ns],
-           haul.distance = distGeo(nasc.ns.sp, haul.ns.sp)*0.000539957)  %>% 
-    mutate(cluster.deep = cluster.match.ns.deep$cluster[nearest.cluster.ns.deep],
-           cluster.distance.deep = distGeo(nasc.ns.sp, cluster.ns.sp.deep)*0.000539957,
-           haul.deep = haul.match.ns.deep$haul[nearest.haul.ns.deep],
-           haul.distance.deep = distGeo(nasc.ns.sp, haul.ns.sp.deep)*0.000539957)
-
+           haul.distance = distGeo(nasc.ns.sp, haul.ns.sp)*0.000539957)  
+  
+  if (exists("cluster.match.ns.deep")) {
+    nasc.match.ns <- nasc.match.ns %>% 
+      mutate(cluster.deep = cluster.match.ns.deep$cluster[nearest.cluster.ns.deep],
+             cluster.distance.deep = distGeo(nasc.ns.sp, cluster.ns.sp.deep)*0.000539957,
+             haul.deep = haul.match.ns.deep$haul[nearest.haul.ns.deep],
+             haul.distance.deep = distGeo(nasc.ns.sp, haul.ns.sp.deep)*0.000539957)
+  }
+  
   # Remove geometry
   nasc.match.ns <- st_set_geometry(nasc.match.ns, NULL) 
   
   # Add clusters and cluster distances to nasc
   nasc.nearshore <- nasc.nearshore %>% 
-    bind_cols(select(nasc.match.ns, cluster, cluster.distance, haul, haul.distance))  %>%
-    bind_cols(select(nasc.match.ns, cluster.deep, cluster.distance.deep, haul.deep, haul.distance.deep))
+    bind_cols(select(nasc.match.ns, cluster, cluster.distance, haul, haul.distance))  
+  
+  if (exists("cluster.match.ns.deep")) {
+    # Add deep nasc clusters and cluster distances to nasc
+    nasc.nearshore <- nasc.nearshore %>% 
+      bind_cols(select(nasc.match.ns, cluster.deep, cluster.distance.deep, haul.deep, haul.distance.deep))
+  }
   
   # ggplot(nasc.nearshore, aes(long, lat, colour = factor(cluster))) + geom_point() + coord_map()
   
   # ggplot(nasc.nearshore, aes(long, lat, colour = factor(cluster))) +
   #   geom_point(show.legend = FALSE) +
-  #   geom_text(data = super.clusters.ns, aes(long, lat, label = factor(cluster),
-  #                                        colour = factor(cluster)), show.legend = FALSE) +
+  #   geom_text(data = super.clusters.ns, 
+  #             aes(long, lat, label = factor(cluster),
+  #                 colour = factor(cluster)), show.legend = FALSE) +
   #   coord_map()
-
+  
   # Save results of processing
   save(nasc.nearshore, file = here("Data/Backscatter/nasc_nearshore.Rdata"))
   
 } else {
   # Load processed data
-  load(here("Data/Backscatter/nasc_nearshore.Rdata"))
-  load(here("Output/clf_nearshore.Rdata"))
-  load(here("Output/seine_summaries.Rdata"))
+  # load(here("Data/Backscatter/nasc_nearshore.Rdata"))
+  # load(here("Output/clf_nearshore.Rdata"))
+  # load(here("Output/seine_summaries.Rdata"))
   # load(here("Output/clf_nearshore_deep.Rdata"))
   # load(here("Output/seine_summaries_deep.Rdata"))
 }
@@ -414,17 +520,19 @@ nasc.super.hauls.ns <- nasc.nearshore %>%
   summarise() %>% 
   st_convex_hull()
 
-nasc.super.clusters.ns.deep <- nasc.nearshore %>%
-  st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-  group_by(cluster.deep) %>%
-  summarise() %>%
-  st_convex_hull()
-
-nasc.super.hauls.ns.deep <- nasc.nearshore %>%
-  st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
-  group_by(haul.deep) %>%
-  summarise() %>%
-  st_convex_hull()
+if ("cluster.deep" %in% names(nasc.nearshore)) {
+  nasc.super.clusters.ns.deep <- nasc.nearshore %>%
+    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
+    group_by(cluster.deep) %>%
+    summarise() %>%
+    st_convex_hull()
+  
+  nasc.super.hauls.ns.deep <- nasc.nearshore %>%
+    st_as_sf(coords = c("long","lat"), crs = crs.geog) %>%
+    group_by(haul.deep) %>%
+    summarise() %>%
+    st_convex_hull()
+}
 
 if (save.figs) {
   nasc.cluster.plot.ns <- base.map +
@@ -480,59 +588,61 @@ if (save.figs) {
 }
 
 if (save.figs) {
-  nasc.cluster.plot.ns.deep <- base.map +
-    # Plot nasc data
-    geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
-    # Plot convex hull around NASC clusters
-    geom_sf(data = nasc.super.clusters.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
-    scale_fill_discrete(name = "Cluster") +
-    scale_colour_manual(name = "Cluster", values = c("Trawl" = "blue", "Purse seine" = "red")) +
-    # Plot cluster midpoints
-    geom_shadowtext(data = filter(clf.ns.deep, CPS.num == 0),
-                    aes(X, Y, label = cluster),
-                    colour = 'gray20', bg.colour = "white", size = 2) +
-    # Plot positive trawl cluster midpoints
-    geom_shadowtext(data = filter(clf.ns.deep, CPS.num > 0, cluster %in% nasc.nearshore$cluster.deep),
-                    aes(X, Y, label = cluster, colour = sample.type),
-                    size = 2, bg.colour = "white", fontface = "bold") +
-    # Plot panel label
-    coord_sf(crs = crs.proj,
-             xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-             ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-
-  nasc.haul.plot.ns.deep <- base.map +
-    # Plot nasc data
-    geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
-    # Plot convex hull around NASC clusters
-    geom_sf(data = nasc.super.hauls.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
-    scale_fill_discrete(name = "Haul") +
-    scale_colour_manual(name = "Haul", values = c("Trawl" = "blue", "Purse seine" = "red")) +
-    # Plot cluster midpoints
-    geom_shadowtext(data = filter(hlf.ns.deep, CPS.num == 0),
-                    aes(X, Y, label = haul),
-                    colour = 'gray20', bg.colour = "white", size = 2) +
-    # Plot positive trawl cluster midpoints
-    geom_shadowtext(data = filter(hlf.ns.deep, CPS.num > 0, haul %in% nasc.nearshore$haul.deep),
-                    aes(X, Y, label = haul, colour = sample.type),
-                    size = 2, bg.colour = "white", fontface = "bold") +
-    # Plot panel label
-    coord_sf(crs = crs.proj,
-             xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-             ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-  
-  ## Map polygons to explore NA values
-  # mapview(nasc.super.hauls.ns.deep)
-  
-  # save trawl plot
-  ggsave(nasc.cluster.plot.ns.deep,
-         filename = here("Figs/fig_nasc_cluster_map_ns_deep.png"),
-         width = map.width, height = map.height)
-
-  ggsave(nasc.haul.plot.ns.deep,
-         filename = here("Figs/fig_nasc_haul_map_ns_deep.png"),
-         width = map.width, height = map.height)
-
-  save(nasc.cluster.plot.ns.deep, file = here("Output/nasc_cluster_plot_ns_deep.Rdata"))
+  if (exists("clf.ns.deep")) {
+    nasc.cluster.plot.ns.deep <- base.map +
+      # Plot nasc data
+      geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
+      # Plot convex hull around NASC clusters
+      geom_sf(data = nasc.super.clusters.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
+      scale_fill_discrete(name = "Cluster") +
+      scale_colour_manual(name = "Cluster", values = c("Trawl" = "blue", "Purse seine" = "red")) +
+      # Plot cluster midpoints
+      geom_shadowtext(data = filter(clf.ns.deep, CPS.num == 0),
+                      aes(X, Y, label = cluster),
+                      colour = 'gray20', bg.colour = "white", size = 2) +
+      # Plot positive trawl cluster midpoints
+      geom_shadowtext(data = filter(clf.ns.deep, CPS.num > 0, cluster %in% nasc.nearshore$cluster.deep),
+                      aes(X, Y, label = cluster, colour = sample.type),
+                      size = 2, bg.colour = "white", fontface = "bold") +
+      # Plot panel label
+      coord_sf(crs = crs.proj,
+               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
+               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
+    
+    nasc.haul.plot.ns.deep <- base.map +
+      # Plot nasc data
+      geom_point(data = nasc.nearshore, aes(X, Y), size = 0.5, show.legend = FALSE) +
+      # Plot convex hull around NASC clusters
+      geom_sf(data = nasc.super.hauls.ns.deep, colour = 'black', alpha = 0.5, show.legend = FALSE) +
+      scale_fill_discrete(name = "Haul") +
+      scale_colour_manual(name = "Haul", values = c("Trawl" = "blue", "Purse seine" = "red")) +
+      # Plot cluster midpoints
+      geom_shadowtext(data = filter(hlf.ns.deep, CPS.num == 0),
+                      aes(X, Y, label = haul),
+                      colour = 'gray20', bg.colour = "white", size = 2) +
+      # Plot positive trawl cluster midpoints
+      geom_shadowtext(data = filter(hlf.ns.deep, CPS.num > 0, haul %in% nasc.nearshore$haul.deep),
+                      aes(X, Y, label = haul, colour = sample.type),
+                      size = 2, bg.colour = "white", fontface = "bold") +
+      # Plot panel label
+      coord_sf(crs = crs.proj,
+               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
+               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
+    
+    ## Map polygons to explore NA values
+    # mapview(nasc.super.hauls.ns.deep)
+    
+    # save trawl plot
+    ggsave(nasc.cluster.plot.ns.deep,
+           filename = here("Figs/fig_nasc_cluster_map_ns_deep.png"),
+           width = map.width, height = map.height)
+    
+    ggsave(nasc.haul.plot.ns.deep,
+           filename = here("Figs/fig_nasc_haul_map_ns_deep.png"),
+           width = map.width, height = map.height)
+    
+    save(nasc.cluster.plot.ns.deep, file = here("Output/nasc_cluster_plot_ns_deep.Rdata"))
+  }
 }
 
 # Map nearshore species proportions -------------------------------------------------------
@@ -544,12 +654,14 @@ if (use.seine.data) {
     select(-cluster) %>% 
     bind_rows(haul.pie)
   
-  cluster.pie.deep <- bind_rows(cluster.pie, set.pie.deep)
-
-  haul.pie.deep <- set.pie.deep %>%
-    select(-cluster) %>%
-    bind_rows(haul.pie)
-
+  if (exists("set.pie.deep")) {
+    cluster.pie.deep <- bind_rows(cluster.pie, set.pie.deep)
+    
+    haul.pie.deep <- set.pie.deep %>%
+      select(-cluster) %>%
+      bind_rows(haul.pie)  
+  }
+  
   # ggplot() +
   #   geom_text(data = cluster.pie, aes(long, lat, label = cluster, colour = sample.type), show.legend = FALSE) +
   #   geom_text(data = set.pie, aes(long, lat, label = cluster, colour = sample.type), show.legend = FALSE) +
@@ -572,22 +684,6 @@ haul.pie.ns <- haul.pie %>%
 haul.pos.ns <- filter(haul.pie.ns, AllCPS > 0) %>% 
   arrange(desc(X))
 
-# Do deep data
-cluster.pie.ns.deep <- cluster.pie.deep %>%
-  filter(cluster %in% unique(nasc.nearshore$cluster.deep),
-         sample.type %in% catch.source.ns)
-
-cluster.pos.ns.deep <- filter(cluster.pie.ns.deep, AllCPS > 0) %>%
-  arrange(desc(X))
-
-# Select only hauls assigned to nasc intervals and included in catch.source.ns
-haul.pie.ns.deep <- haul.pie.deep %>%
-  filter(haul %in% unique(nasc.nearshore$haul.deep),
-         sample.type %in% catch.source.ns)
-
-haul.pos.ns.deep <- filter(haul.pie.ns.deep, AllCPS > 0) %>%
-  arrange(desc(X))
-
 # Substitute very small value for species with zero catch, just for pie charts
 if (nrow(cluster.pos.ns) > 0) {
   cluster.pos.ns <- cluster.pos.ns %>% 
@@ -599,22 +695,41 @@ if (nrow(haul.pos.ns) > 0) {
     replace(. == 0, 0.0000001) 
 }
 
-if (nrow(cluster.pos.ns.deep) > 0) {
-  cluster.pos.ns.deep <- cluster.pos.ns.deep %>%
-    replace(. == 0, 0.0000001)
-}
-
-if (nrow(haul.pos.ns.deep) > 0) {
-  haul.pos.ns.deep <- haul.pos.ns.deep %>%
-    replace(. == 0, 0.0000001)
-}
-
 # Filter for empty trawls
 cluster.zero.ns <- filter(cluster.pie.ns, AllCPS == 0)
 haul.zero.ns    <- filter(haul.pie.ns, AllCPS == 0)
 
-cluster.zero.ns.deep <- filter(cluster.pie.ns.deep, AllCPS == 0)
-haul.zero.ns.deep    <- filter(haul.pie.ns.deep, AllCPS == 0)
+if (exists("cluster.pie.deep")) {
+  # Do deep data
+  cluster.pie.ns.deep <- cluster.pie.deep %>%
+    filter(cluster %in% unique(nasc.nearshore$cluster.deep),
+           sample.type %in% catch.source.ns)
+  
+  cluster.pos.ns.deep <- filter(cluster.pie.ns.deep, AllCPS > 0) %>%
+    arrange(desc(X))
+  
+  # Select only hauls assigned to nasc intervals and included in catch.source.ns
+  haul.pie.ns.deep <- haul.pie.deep %>%
+    filter(haul %in% unique(nasc.nearshore$haul.deep),
+           sample.type %in% catch.source.ns)
+  
+  haul.pos.ns.deep <- filter(haul.pie.ns.deep, AllCPS > 0) %>%
+    arrange(desc(X))  
+  
+  if (nrow(cluster.pos.ns.deep) > 0) {
+    cluster.pos.ns.deep <- cluster.pos.ns.deep %>%
+      replace(. == 0, 0.0000001)
+  }
+  
+  if (nrow(haul.pos.ns.deep) > 0) {
+    haul.pos.ns.deep <- haul.pos.ns.deep %>%
+      replace(. == 0, 0.0000001)
+  }
+  
+  # Filter for empty trawls
+  cluster.zero.ns.deep <- filter(cluster.pie.ns.deep, AllCPS == 0)
+  haul.zero.ns.deep    <- filter(haul.pie.ns.deep, AllCPS == 0)
+}
 
 ## NOTE: These plots show proportion of catch by weight, NOT acoustic proportion
 ## The acoustic proportions get plotted below
@@ -649,22 +764,30 @@ nasc.nearshore.tmp <- nasc.nearshore
 
 if (cluster.source["NS"] == "cluster") {
   nasc.nearshore <- nasc.nearshore.tmp %>% 
-    left_join(select(clf.ns, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
+    left_join(select(clf.ns, -lat, -long, -X, -Y), by = c("cluster" = "cluster"))
+  # left_join(select(clf.ns, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
   
-  nasc.nearshore.deep <- nasc.nearshore.tmp %>%
-    left_join(select(clf.ns.deep, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
+  if (exists("clf.ns.deep"))
+    nasc.nearshore.deep <- nasc.nearshore.tmp %>%
+      left_join(select(clf.ns.deep, -lat, -long, -X, -Y), by = c("cluster" = "cluster"))
+  # left_join(select(clf.ns.deep, -lat, -long, -X, -Y, -haul), by = c("cluster" = "cluster"))
   
 } else {
   nasc.nearshore <- nasc.nearshore.tmp %>% 
     left_join(select(hlf.ns, -lat, -long, -X, -Y,-cluster), by = c("haul" = "haul"))
   
-  nasc.nearshore.deep <- nasc.nearshore.tmp %>%
-    left_join(select(hlf.ns.deep, -lat, -long, -X, -Y,-cluster), by = c("haul" = "haul"))
+  if (exists("hlf.ns.deep"))
+    nasc.nearshore.deep <- nasc.nearshore.tmp %>%
+      left_join(select(hlf.ns.deep, -lat, -long, -X, -Y,-cluster), by = c("haul" = "haul"))
 }
 
 # Save results
 save(nasc.nearshore, file = here("Output/cps_nasc_prop_ns.Rdata"))
-save(nasc.nearshore.deep, file = here("Output/cps_nasc_prop_ns_deep.Rdata"))
+
+if(exists("nasc.nearshore.deep")) {
+  save(nasc.nearshore.deep, file = here("Output/cps_nasc_prop_ns_deep.Rdata"))  
+}
+
 
 # Summarize transects -----------------------------------------------------
 # Summarize nasc data
@@ -712,14 +835,16 @@ nasc.prop.all.ns <- nasc.nearshore %>%
          `Clupea pallasii`       = cps.nasc*prop.her,
          `Etrumeus acuminatus`   = cps.nasc*prop.rher) 
 
-# For intervals with deep backscatter
-nasc.prop.all.ns.deep <- nasc.nearshore.deep %>%
-  mutate(`Engraulis mordax`      = cps.nasc.deep*prop.anch,
-         `Sardinops sagax`       = cps.nasc.deep*prop.sar,
-         `Trachurus symmetricus` = cps.nasc.deep*prop.jack,
-         `Scomber japonicus`     = cps.nasc.deep*prop.mack,
-         `Clupea pallasii`       = cps.nasc.deep*prop.her,
-         `Etrumeus acuminatus`   = cps.nasc.deep*prop.rher)
+if(exists("nasc.nearshore.deep")) {
+  # For intervals with deep backscatter
+  nasc.prop.all.ns.deep <- nasc.nearshore.deep %>%
+    mutate(`Engraulis mordax`      = cps.nasc.deep*prop.anch,
+           `Sardinops sagax`       = cps.nasc.deep*prop.sar,
+           `Trachurus symmetricus` = cps.nasc.deep*prop.jack,
+           `Scomber japonicus`     = cps.nasc.deep*prop.mack,
+           `Clupea pallasii`       = cps.nasc.deep*prop.her,
+           `Etrumeus acuminatus`   = cps.nasc.deep*prop.rher)
+}
 
 # Prepare nasc.prop.all for facet plotting
 nasc.prop.spp.ns <- nasc.prop.all.ns %>% 
@@ -727,10 +852,12 @@ nasc.prop.spp.ns <- nasc.prop.all.ns %>%
          `Scomber japonicus`, `Clupea pallasii`, `Etrumeus acuminatus`) %>% 
   gather(scientificName, nasc, -X, -Y)
 
-nasc.prop.spp.ns.deep <- nasc.prop.all.ns.deep %>%
-  select(X, Y, `Engraulis mordax`, `Sardinops sagax`, `Trachurus symmetricus`,
-         `Scomber japonicus`, `Clupea pallasii`, `Etrumeus acuminatus`) %>%
-  gather(scientificName, nasc, -X, -Y)
+if(exists("nasc.prop.spp.ns.deep")) {
+  nasc.prop.spp.ns.deep <- nasc.prop.all.ns.deep %>%
+    select(X, Y, `Engraulis mordax`, `Sardinops sagax`, `Trachurus symmetricus`,
+           `Scomber japonicus`, `Clupea pallasii`, `Etrumeus acuminatus`) %>%
+    gather(scientificName, nasc, -X, -Y)
+}
 
 if (save.figs) {
   # Create a base map with relative CPS backscatter
@@ -749,36 +876,41 @@ if (save.figs) {
              xlim = c(map.bounds["xmin"], map.bounds["xmax"]), 
              ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
   
-  map.prop.all.ns.deep <- base.map +
-    # Plot backscatter for all CPS nasc
-    geom_point(data = nasc.prop.all.ns.deep, aes(X, Y, size = cps.nasc.deep),
-               colour = "gray20") +
-    # Plot proportion of backscatter from each species present
-    geom_point(data = filter(nasc.prop.spp.ns.deep, nasc > 0),
-               aes(X, Y, size = nasc), colour = "red") +
-    # Facet by species
-    facet_wrap(~scientificName, nrow = 2) +
-    theme(strip.background.x = element_blank(),
-          strip.text.x       = element_text(face = "italic")) +
-    coord_sf(crs = crs.proj,
-             xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
-             ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
-  
   # Save map
   ggsave(here("Figs/fig_nasc_acoustic_proportions_ns.png"), map.prop.all.ns,
          width = map.width*3, height = map.height*2)
   
-  ggsave(here("Figs/fig_nasc_acoustic_proportions_ns_deep.png"), map.prop.all.ns.deep,
-         width = map.width*3, height = map.height*2)
-  
   # Save plot objects
   save(map.prop.all.ns, file = here("Output/acoustic_proportion_maps_ns.Rdata"))
-  save(map.prop.all.ns.deep, file = here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
+  
+  if(exists("nasc.prop.spp.ns.deep")) {
+    map.prop.all.ns.deep <- base.map +
+      # Plot backscatter for all CPS nasc
+      geom_point(data = nasc.prop.all.ns.deep, aes(X, Y, size = cps.nasc.deep),
+                 colour = "gray20") +
+      # Plot proportion of backscatter from each species present
+      geom_point(data = filter(nasc.prop.spp.ns.deep, nasc > 0),
+                 aes(X, Y, size = nasc), colour = "red") +
+      # Facet by species
+      facet_wrap(~scientificName, nrow = 2) +
+      theme(strip.background.x = element_blank(),
+            strip.text.x       = element_text(face = "italic")) +
+      coord_sf(crs = crs.proj,
+               xlim = c(map.bounds["xmin"], map.bounds["xmax"]),
+               ylim = c(map.bounds["ymin"], map.bounds["ymax"]))
+    
+    ggsave(here("Figs/fig_nasc_acoustic_proportions_ns_deep.png"), map.prop.all.ns.deep,
+           width = map.width*3, height = map.height*2)
+    
+    save(map.prop.all.ns.deep, file = here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
+  }
   
 } else {
   # Load plot objects
   load(here("Output/acoustic_proportion_maps_ns.Rdata"))
-  load(here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
+  
+  if(exists(here("Output/acoustic_proportion_maps_ns_deep.Rdata")))
+    load(here("Output/acoustic_proportion_maps_ns_deep.Rdata"))
 }
 
 # Calculate nearshore acoustic biomass density -----------------------------
@@ -793,14 +925,16 @@ nasc.nearshore <- nasc.nearshore %>%
     rher.dens = cps.nasc*prop.rher / (4*pi*sigmawg.rher) / 1000)
 
 # Deep density
-nasc.nearshore.deep <- nasc.nearshore.deep %>%
-  mutate(
-    anch.dens = cps.nasc.deep*prop.anch / (4*pi*sigmawg.anch) / 1000,
-    her.dens  = cps.nasc.deep*prop.her  / (4*pi*sigmawg.her)  / 1000,
-    jack.dens = cps.nasc.deep*prop.jack / (4*pi*sigmawg.jack) / 1000,
-    mack.dens = cps.nasc.deep*prop.mack / (4*pi*sigmawg.mack) / 1000,
-    sar.dens  = cps.nasc.deep*prop.sar  / (4*pi*sigmawg.sar)  / 1000,
-    rher.dens = cps.nasc.deep*prop.rher / (4*pi*sigmawg.rher) / 1000)
+if(exists("nasc.nearshore.deep")) {
+  nasc.nearshore.deep <- nasc.nearshore.deep %>%
+    mutate(
+      anch.dens = cps.nasc.deep*prop.anch / (4*pi*sigmawg.anch) / 1000,
+      her.dens  = cps.nasc.deep*prop.her  / (4*pi*sigmawg.her)  / 1000,
+      jack.dens = cps.nasc.deep*prop.jack / (4*pi*sigmawg.jack) / 1000,
+      mack.dens = cps.nasc.deep*prop.mack / (4*pi*sigmawg.mack) / 1000,
+      sar.dens  = cps.nasc.deep*prop.sar  / (4*pi*sigmawg.sar)  / 1000,
+      rher.dens = cps.nasc.deep*prop.rher / (4*pi*sigmawg.rher) / 1000)
+}
 
 # Add deep density to shallow density
 # This is where the magic happens, I think.
@@ -989,8 +1123,8 @@ for (v in unique(nasc.nearshore$vessel.name)) {
   # Get latitude range for backscatter data
   nasc.nearshore.summ <- nasc.nearshore %>% 
     filter(vessel.name == v) #%>% 
-    # summarise(lat.min = min(lat) - 0.1,
-    #           lat.max = max(lat) + 0.1)
+  # summarise(lat.min = min(lat) - 0.1,
+  #           lat.max = max(lat) + 0.1)
   
   # Extract only waypoints in the survey region
   region.wpts <- wpts %>% 
@@ -1111,14 +1245,13 @@ for (v in unique(nasc.nearshore$vessel.name)) {
           lat.i  = lat[which.max(long)],
           long.i = max(long),
           lat.o  = lat[which.min(long)],
-          long.o = min(long)
-        ) %>%
+          long.o = min(long)) %>%
         left_join(select(tx.nn.ns, transect.name, spacing)) %>%
         mutate(
           brg = swfscMisc::bearing(lat.i, long.i,
                                    lat.o, long.o)[1])
       
-      # ggplot() + geom_point(data = tx.ends.ns.k, aes(long.i, lat.i)) + 
+      # ggplot() + geom_point(data = tx.ends.ns.k, aes(long.i, lat.i)) +
       #   geom_point(data = tx.ends.ns.k, aes(long.o, lat.o), colour = "blue")
       
       # Get original inshore transect ends -------------------------------------------
@@ -1137,8 +1270,8 @@ for (v in unique(nasc.nearshore$vessel.name)) {
         select(-lat.o, -long.o) %>% 
         rename(lat = lat.i, long = long.i) %>% 
         mutate(
-          lat  = destination(lat, long, brg + 90, spacing/2, units = "nm")["lat"],
-          long = destination(lat, long, brg + 90, spacing/2, units = "nm")["lon"],
+          lat  = swfscMisc::destination(lat, long, brg + 90, spacing/2, units = "nm")["lat"],
+          long = swfscMisc::destination(lat, long, brg + 90, spacing/2, units = "nm")["lon"],
           grp = "north",
           loc = "inshore",
           order = 1)
@@ -1234,7 +1367,7 @@ for (v in unique(nasc.nearshore$vessel.name)) {
         mutate(key = paste(transect.name, grp),
                region = k) 
       
-      # ggplot(strata.points.ns.k, aes(long, lat)) + geom_polygon() + coord_map()
+      # ggplot(strata.points.ns.k) + geom_sf()
       
       # Create polygons
       ns.poly.k <- strata.points.ns.k %>% 
@@ -1956,15 +2089,17 @@ for (i in unique(strata.final.ns$scientificName)) {
         left_join(strata.temp) %>% 
         filter(!is.na(stratum))
       
-      # Subset deep NASC
-      nasc.ns.temp.deep <- nasc.nearshore.deep %>%
-        select(-stratum) %>%
-        left_join(strata.temp) %>%
-        filter(!is.na(stratum)) %>%
-        # Rename for compatibility with atm::estimate_point()
-        mutate(cps.nasc = cps.nasc.deep)
-      
       # ggplot(nasc.ns.temp, aes(long, lat, size = cps.nasc, colour = factor(stratum))) + geom_point() + coord_map()
+      
+      # Subset deep NASC
+      if(adj.deep.nasc) {
+        nasc.ns.temp.deep <- nasc.nearshore.deep %>%
+          select(-stratum) %>%
+          left_join(strata.temp) %>%
+          filter(!is.na(stratum)) %>%
+          # Rename for compatibility with atm::estimate_point()
+          mutate(cps.nasc = cps.nasc.deep)  
+      }
       
       # Summarize nasc by stratum
       nasc.ns.temp.summ <- nasc.ns.temp %>% 
@@ -1996,36 +2131,47 @@ for (i in unique(strata.final.ns$scientificName)) {
         point.estimates.ns <- bind_rows(point.estimates.ns,
                                         data.frame(scientificName = i, vessel.name = j,
                                                    estimate_point(nasc.ns.temp, stratum.info.nearshore, species = i)))
-        # Calculate deep point estimates
-        point.estimates.ns.deep <- bind_rows(point.estimates.ns.deep,
-                                             data.frame(scientificName = i, vessel.name = j,
-                                                        estimate_point(nasc.ns.temp.deep, stratum.info.nearshore, species = i)))
+        if(adj.deep.nasc) {
+          # Calculate deep point estimates
+          point.estimates.ns.deep <- bind_rows(point.estimates.ns.deep,
+                                               data.frame(scientificName = i, vessel.name = j,
+                                                          estimate_point(nasc.ns.temp.deep, stratum.info.nearshore, species = i)))  
+        }
+        
       } else {
         point.estimates.ns <- data.frame(scientificName = i, vessel.name = j,
                                          estimate_point(nasc.ns.temp, stratum.info.nearshore, species = i))
-        
-        point.estimates.ns.deep <- data.frame(scientificName = i, vessel.name = j,
-                                              estimate_point(nasc.ns.temp.deep, stratum.info.nearshore, species = i))
+        if(adj.deep.nasc) {
+          # Calculate deep point estimates
+          point.estimates.ns.deep <- data.frame(scientificName = i, vessel.name = j,
+                                                estimate_point(nasc.ns.temp.deep, stratum.info.nearshore, species = i))  
+        }
       }
     }
   }
 }
 
 # Combine deep and shallow results
-point.estimates.ns <- point.estimates.ns %>%
-  left_join(select(point.estimates.ns.deep, -area, biomass.deep = biomass.total)) %>%
-  mutate(biomass.corr = biomass.total + biomass.deep)
+if(adj.deep.nasc) {
+  point.estimates.ns <- point.estimates.ns %>%
+    left_join(select(point.estimates.ns.deep, -area, biomass.deep = biomass.total)) %>%
+    mutate(biomass.corr = biomass.total + biomass.deep)  
+}
 
 # Remove strata with zero biomass
 point.estimates.ns <- filter(point.estimates.ns, biomass.total != 0)
 
 # Add stock designations to point estimates
 point.estimates.ns <- point.estimates.ns %>% 
-  left_join(strata.summ.nearshore) %>% 
-  # Remove and rename temporary variables
-  select(-biomass.total, -biomass.deep) %>%
-  # New biomass.total based on the combination of the shallow and deep NASC
-  rename(biomass.total = biomass.corr)
+  left_join(strata.summ.nearshore) 
+
+if (adj.deep.nasc) {
+  point.estimates.ns <- point.estimates.ns %>% 
+    # Remove and rename temporary variables
+    select(-biomass.total, -biomass.deep) %>%
+    # New biomass.total based on the combination of the shallow and deep NASC
+    rename(biomass.total = biomass.corr)
+}
 
 save(point.estimates.ns, 
      file = here("Output/biomass_point_estimates_ns.Rdata"))
@@ -2251,13 +2397,13 @@ if (do.bootstrap) {
         
         # Calculate abundance and biomass all ways ----
         boot.comp.temp.ns <- estimate_bootstrap(nasc.temp, cluster.final.ns, k, 
-                                             stratum.area = stratum.area, 
-                                             species = i, do.lf = do.lf, 
-                                             boot.number = 0)$data.frame
+                                                stratum.area = stratum.area, 
+                                                species = i, do.lf = do.lf, 
+                                                boot.number = 0)$data.frame
         
         # Extract abundance estimates
         boot.comp.ns <- data.frame(Species = i, Stratum = k, 
-                                select(boot.comp.temp.ns, abundance, everything()))
+                                   select(boot.comp.temp.ns, abundance, everything()))
         
         if (exists("bootstrap.comp.ns")) {
           bootstrap.comp.ns <- bind_rows(bootstrap.comp.ns, boot.comp.ns) %>% 
@@ -2624,8 +2770,10 @@ if (save.figs) {
 }
 
 if (save.figs) {
-  # Plot nearshore backscatter and purse seine data
-  source(here("Code/plotSeine.R"))
+  if (exists("set.catch")) {
+    # Plot nearshore backscatter and purse seine data
+    source(here("Code/plotSeine.R")) 
+  }
 }
 
 # Plot sA for CPS -------------------------------------------

--- a/Code/plot_cluster_proportion_wt_nearshore.R
+++ b/Code/plot_cluster_proportion_wt_nearshore.R
@@ -21,8 +21,6 @@ if (nrow(cluster.pos.ns) > 0) {
     # Plot transects data
     geom_sf(data = filter(transects.sf, Type == "Nearshore"), size = 0.5, colour = "gray70", 
             alpha = 0.75, linetype = "dashed") +
-    # plot ship track data
-    # geom_sf(data = nav.paths.sf, colour = "gray50", size = 0.5, alpha = 0.5) +
     # Plot trawl pies
     geom_scatterpie(data = cluster.pos.ns, aes(X, Y, group = cluster, r = pie.radius, colour = sample.type),
                     cols = pie.cols[names(pie.cols) %in% pie.spp.ns],
@@ -90,8 +88,6 @@ if (exists("cluster.pos.ns.deep")) {
       # Plot transects data
       geom_sf(data = filter(transects.sf, Type == "Nearshore"), size = 0.5, colour = "gray70", 
               alpha = 0.75, linetype = "dashed") +
-      # plot ship track data
-      # geom_sf(data = nav.paths.sf, colour = "gray50", size = 0.5, alpha = 0.5) +
       # Plot trawl pies
       geom_scatterpie(data = cluster.pos.ns.deep, aes(X, Y, group = cluster, r = pie.radius, colour = sample.type),
                       cols = pie.cols[names(pie.cols) %in% pie.spp.ns.deep],

--- a/Code/plot_cluster_proportion_wt_nearshore.R
+++ b/Code/plot_cluster_proportion_wt_nearshore.R
@@ -1,6 +1,19 @@
-# Map trawl species proportions -------------------------------------------------------
-# Get species present in the trawl catch
-pie.spp.ns <- sort(unique(set.catch$scientificName))
+# Map cluster species proportions -------------------------------------------------------
+# Use cluster.pos.ns to identify species present in the nearshore biomass estimation
+# More robust than set.catch when seine data are not 
+pie.cols.ns <- cluster.pos.ns %>% 
+  select(cluster:RndHerring) %>% 
+  pivot_longer(cols = -cluster, names_to = "spp", values_to = "totalWeight") %>% 
+  group_by(spp) %>% 
+  summarise(meanWeight = mean(totalWeight)) %>% 
+  filter(meanWeight > 0.0000001) %>% 
+  pluck("spp")
+
+# Get species present in the nearshore catch
+pie.spp.ns <- sort(names(pie.cols)[pie.cols %in% pie.cols.ns])
+
+# Get species present in the nearshore catch
+# pie.spp.ns <- sort(unique(set.catch$scientificName))
 
 if (nrow(cluster.pos.ns) > 0) {
   # Create trawl haul figure

--- a/Code/plot_haul_proportion_wt_nearshore.R
+++ b/Code/plot_haul_proportion_wt_nearshore.R
@@ -12,17 +12,12 @@ pie.cols.ns <- cluster.pos.ns %>%
 # Get species present in the nearshore catch
 pie.spp.ns <- sort(names(pie.cols)[pie.cols %in% pie.cols.ns])
 
-# Get species present in the nearshore catch
-# pie.spp.ns <- sort(unique(set.catch$scientificName))
-
 if (nrow(haul.pos.ns) > 0) {
   # Create trawl haul figure
   set.pie.haul.wt <- base.map +
     # Plot transects data
     geom_sf(data = filter(transects.sf, Type == "Nearshore"), size = 0.5, colour = "gray70", 
             alpha = 0.75, linetype = "dashed") +
-    # # plot ship track data
-    # geom_sf(data = nav.paths.sf, colour = "gray50", size = 0.5, alpha = 0.5) +
     # Plot trawl pies
     geom_scatterpie(data = haul.pos.ns, aes(X, Y, group = haul, r = pie.radius, colour = sample.type),
                     cols = pie.cols[names(pie.cols) %in% pie.spp.ns],
@@ -89,8 +84,6 @@ if (exists("haul.pos.ns.deep")) {
       # Plot transects data
       geom_sf(data = filter(transects.sf, Type == "Nearshore"), size = 0.5, colour = "gray70", 
               alpha = 0.75, linetype = "dashed") +
-      # plot ship track data
-      # geom_sf(data = nav.paths.sf, colour = "gray50", size = 0.5, alpha = 0.5) +
       # Plot trawl pies
       geom_scatterpie(data = haul.pos.ns.deep, aes(X, Y, group = haul, r = pie.radius, colour = sample.type),
                       cols = pie.cols[names(pie.cols) %in% pie.spp.ns.deep],

--- a/Code/plot_haul_proportion_wt_nearshore.R
+++ b/Code/plot_haul_proportion_wt_nearshore.R
@@ -1,6 +1,19 @@
-# Map trawl species proportions -------------------------------------------------------
-# Get species present in the trawl catch
-pie.spp.ns <- sort(unique(set.catch$scientificName))
+# Map cluster species proportions -------------------------------------------------------
+# Use cluster.pos.ns to identify species present in the nearshore biomass estimation
+# More robust than set.catch when seine data are not 
+pie.cols.ns <- cluster.pos.ns %>% 
+  select(cluster:RndHerring) %>% 
+  pivot_longer(cols = -cluster, names_to = "spp", values_to = "totalWeight") %>% 
+  group_by(spp) %>% 
+  summarise(meanWeight = mean(totalWeight)) %>% 
+  filter(meanWeight > 0.0000001) %>% 
+  pluck("spp")
+
+# Get species present in the nearshore catch
+pie.spp.ns <- sort(names(pie.cols)[pie.cols %in% pie.cols.ns])
+
+# Get species present in the nearshore catch
+# pie.spp.ns <- sort(unique(set.catch$scientificName))
 
 if (nrow(haul.pos.ns) > 0) {
   # Create trawl haul figure

--- a/Data/Nav/waypoints_2506SH.csv
+++ b/Data/Nav/waypoints_2506SH.csv
@@ -498,7 +498,7 @@ Transect,Waypoint,Latitude,Longitude,Type,Region,Depth
 127,127.2N,45.429274,-124.088992,Nearshore,WA/OR,-85
 128,128.1N,45.547611,-123.957008,Nearshore,WA/OR,-5
 128,128.2N,45.546821,-124.074742,Nearshore,WA/OR,-77
-129,129.1N,45.663815,-123.950349,Nearshore,WA/OR,-0
+129,129.1N,45.663815,-123.950349,Nearshore,WA/OR,0
 129,129.2N,45.663083,-124.057589,Nearshore,WA/OR,-70
 130,130.1N,45.779835,-123.975872,Nearshore,WA/OR,70
 130,130.2N,45.778987,-124.09824,Nearshore,WA/OR,-79
@@ -507,7 +507,7 @@ Transect,Waypoint,Latitude,Longitude,Type,Region,Depth
 132,132.1N,46.01261,-123.938889,Nearshore,WA/OR,-8
 132,132.2N,46.013229,-124.060529,Nearshore,WA/OR,-54
 133,133.1N,46.128736,-123.965776,Nearshore,WA/OR,-2
-133,133.2N,46.127872000000004,-124.084695,Nearshore,WA/OR,-39
+133,133.2N,46.127872,-124.084695,Nearshore,WA/OR,-39
 134,134.1N,46.244525,-124.043207,Nearshore,WA/OR,-6
 134,134.2N,46.24445,-124.163237,Nearshore,WA/OR,-22
 135,135.1N,46.360719,-124.07,Nearshore,WA/OR,-10
@@ -546,85 +546,85 @@ Transect,Waypoint,Latitude,Longitude,Type,Region,Depth
 151,151.2N,48.221932,-124.830425,Nearshore,WA/OR,-39
 152,152.1N,48.340729,-124.706757,Nearshore,WA/OR,-16
 152,152.2N,48.339363,-124.833643,Nearshore,WA/OR,-59
-284,284.1N,34.106322,-119.940104,Nearshore,S. CA Bight,-98
-284,284.2N,34.076899,-119.922274,Nearshore,S. CA Bight,-47
-285,285.1N,34.047626,-119.8984,Nearshore,S. CA Bight,-27
-285,285.2N,34.030184,-119.934803,Nearshore,S. CA Bight,-41
-286,286.1N,34.00106,-119.88762,Nearshore,S. CA Bight,-66
-286,286.2N,33.987656,-119.922887,Nearshore,S. CA Bight,-55
-287,287.1N,33.970173,-119.859241,Nearshore,S. CA Bight,-33
-287,287.2N,33.94066,-119.882579,Nearshore,S. CA Bight,-196
-288,288.1N,33.960676,-119.807565,Nearshore,S. CA Bight,-10
-288,288.2N,33.928754,-119.805805,Nearshore,S. CA Bight,-279
-289,289.1N,33.96072,-119.752252,Nearshore,S. CA Bight,11
-289,289.2N,33.930628,-119.748469,Nearshore,S. CA Bight,-327
-290,290.1N,33.96371,-119.707908,Nearshore,S. CA Bight,32
-290,290.2N,33.933624,-119.691844,Nearshore,S. CA Bight,-347
-291,291.1N,33.98364,-119.660782,Nearshore,S. CA Bight,11
-291,291.2N,33.953843,-119.646684,Nearshore,S. CA Bight,-77
-292,292.1N,33.985423,-119.610696,Nearshore,S. CA Bight,207
-292,292.2N,33.955314,-119.601062,Nearshore,S. CA Bight,-150
-293,293.1N,33.994492,-119.55954,Nearshore,S. CA Bight,18
-293,293.2N,33.96474,-119.541579,Nearshore,S. CA Bight,-350
-294,294.1N,34.01872,-119.537423,Nearshore,S. CA Bight,57
-294,294.2N,34.004007,-119.501629,Nearshore,S. CA Bight,-52
-295,295.1N,34.042599,-119.525033,Nearshore,S. CA Bight,-30
-295,295.2N,34.060013,-119.489294,Nearshore,S. CA Bight,-84
-296,296.1N,34.053867,-119.551648,Nearshore,S. CA Bight,-72
-296,296.2N,34.087281,-119.539258,Nearshore,S. CA Bight,-188
-297,297.1N,34.056365,-119.593209,Nearshore,S. CA Bight,-80
-297,297.2N,34.091002,-119.602497,Nearshore,S. CA Bight,-179
-298,298.1N,34.022835,-119.654481,Nearshore,S. CA Bight,-31
-298,298.2N,34.054047,-119.639671,Nearshore,S. CA Bight,-90
-299,299.1N,34.035176,-119.693999,Nearshore,S. CA Bight,10
-299,299.2N,34.067531,-119.676456,Nearshore,S. CA Bight,-88
-300,300.1N,34.050742,-119.734077,Nearshore,S. CA Bight,179
-300,300.2N,34.082964,-119.715591,Nearshore,S. CA Bight,-89
-301,301.1N,34.062664,-119.779654,Nearshore,S. CA Bight,26
-301,301.2N,34.095295,-119.768646,Nearshore,S. CA Bight,-90
-302,302.1N,34.100976,-119.821473,Nearshore,S. CA Bight,-92
-302,302.2N,34.067661,-119.833305,Nearshore,S. CA Bight,192
-303,303.1N,34.076995,-119.870488,Nearshore,S. CA Bight,18
-303,303.2N,34.110855,-119.87069,Nearshore,S. CA Bight,-97
-327,327.1N,33.481359,-118.572541,Nearshore,S. CA Bight,38
-327,327.2N,33.521721,-118.573908,Nearshore,S. CA Bight,-493
-328,328.1N,33.480539,-118.609642,Nearshore,S. CA Bight,-54
-328,328.2N,33.501471,-118.640393,Nearshore,S. CA Bight,-311
-329,329.1N,33.460002,-118.594251,Nearshore,S. CA Bight,7
-329,329.2N,33.437033,-118.622772,Nearshore,S. CA Bight,-427
-330,330.1N,33.433816,-118.567416,Nearshore,S. CA Bight,11
-330,330.2N,33.40981,-118.595655,Nearshore,S. CA Bight,-598
-331,331.1N,33.422557,-118.51837,Nearshore,S. CA Bight,-9
-331,331.2N,33.397867,-118.543764,Nearshore,S. CA Bight,-374
-332,332.1N,33.399431,-118.492245,Nearshore,S. CA Bight,-33
-332,332.2N,33.37736,-118.521972,Nearshore,S. CA Bight,-206
-333,333.1N,33.358136,-118.492304,Nearshore,S. CA Bight,-19
-333,333.2N,33.335904,-118.522348,Nearshore,S. CA Bight,-85
-334,334.1N,33.323293,-118.470095,Nearshore,S. CA Bight,-50
-334,334.2N,33.299251,-118.49831,Nearshore,S. CA Bight,-263
-335,335.1N,33.31582,-118.43314,Nearshore,S. CA Bight,186
-335,335.2N,33.284958,-118.442422,Nearshore,S. CA Bight,-446
-336,336.1N,33.31325,-118.393192,Nearshore,S. CA Bight,-57
-336,336.2N,33.279763,-118.397749,Nearshore,S. CA Bight,-717
-337,337.1N,33.303205,-118.351038,Nearshore,S. CA Bight,-5
-337,337.2N,33.269754,-118.357541,Nearshore,S. CA Bight,-527
-338,338.1N,33.299378,-118.316289,Nearshore,S. CA Bight,295
-338,338.2N,33.267801,-118.304896,Nearshore,S. CA Bight,-229
-339,339.1N,33.308464,-118.301993,Nearshore,S. CA Bight,72
-339,339.2N,33.308122,-118.261527,Nearshore,S. CA Bight,-186
-340,340.1N,33.333336,-118.306605,Nearshore,S. CA Bight,-56
-340,340.2N,33.35007,-118.270147,Nearshore,S. CA Bight,-358
-341,341.1N,33.358873,-118.326163,Nearshore,S. CA Bight,-56
-341,341.2N,33.378055,-118.293258,Nearshore,S. CA Bight,-360
-342,342.1N,33.384007,-118.355025,Nearshore,S. CA Bight,-42
-342,342.2N,33.405032,-118.319137,Nearshore,S. CA Bight,-315
-343,343.1N,33.411552,-118.366314,Nearshore,S. CA Bight,51
-343,343.2N,33.43221,-118.335137,Nearshore,S. CA Bight,-368
-344,344.1N,33.423186,-118.39604,Nearshore,S. CA Bight,-128
-344,344.2N,33.453778,-118.373027,Nearshore,S. CA Bight,-630
-345,345.1N,33.436967,-118.4345,Nearshore,S. CA Bight,-129
-345,345.2N,33.468473,-118.417416,Nearshore,S. CA Bight,-664
-346,346.1N,33.454707,-118.483767,Nearshore,S. CA Bight,-74
-346,346.2N,33.48501,-118.462914,Nearshore,S. CA Bight,-672
-347,347.1N,33.478477,-118.53638,Nearshore,S. CA Bight,-3
-347,347.2N,33.507898,-118.515911,Nearshore,S. CA Bight,-553
+284,284.1N,34.106322,-119.940104,Nearshore,Santa Cruz Island,-98
+284,284.2N,34.076899,-119.922274,Nearshore,Santa Cruz Island,-47
+285,285.1N,34.047626,-119.8984,Nearshore,Santa Cruz Island,-27
+285,285.2N,34.030184,-119.934803,Nearshore,Santa Cruz Island,-41
+286,286.1N,34.00106,-119.88762,Nearshore,Santa Cruz Island,-66
+286,286.2N,33.987656,-119.922887,Nearshore,Santa Cruz Island,-55
+287,287.1N,33.970173,-119.859241,Nearshore,Santa Cruz Island,-33
+287,287.2N,33.94066,-119.882579,Nearshore,Santa Cruz Island,-196
+288,288.1N,33.960676,-119.807565,Nearshore,Santa Cruz Island,-10
+288,288.2N,33.928754,-119.805805,Nearshore,Santa Cruz Island,-279
+289,289.1N,33.96072,-119.752252,Nearshore,Santa Cruz Island,11
+289,289.2N,33.930628,-119.748469,Nearshore,Santa Cruz Island,-327
+290,290.1N,33.96371,-119.707908,Nearshore,Santa Cruz Island,32
+290,290.2N,33.933624,-119.691844,Nearshore,Santa Cruz Island,-347
+291,291.1N,33.98364,-119.660782,Nearshore,Santa Cruz Island,11
+291,291.2N,33.953843,-119.646684,Nearshore,Santa Cruz Island,-77
+292,292.1N,33.985423,-119.610696,Nearshore,Santa Cruz Island,207
+292,292.2N,33.955314,-119.601062,Nearshore,Santa Cruz Island,-150
+293,293.1N,33.994492,-119.55954,Nearshore,Santa Cruz Island,18
+293,293.2N,33.96474,-119.541579,Nearshore,Santa Cruz Island,-350
+294,294.1N,34.01872,-119.537423,Nearshore,Santa Cruz Island,57
+294,294.2N,34.004007,-119.501629,Nearshore,Santa Cruz Island,-52
+295,295.1N,34.042599,-119.525033,Nearshore,Santa Cruz Island,-30
+295,295.2N,34.060013,-119.489294,Nearshore,Santa Cruz Island,-84
+296,296.1N,34.053867,-119.551648,Nearshore,Santa Cruz Island,-72
+296,296.2N,34.087281,-119.539258,Nearshore,Santa Cruz Island,-188
+297,297.1N,34.056365,-119.593209,Nearshore,Santa Cruz Island,-80
+297,297.2N,34.091002,-119.602497,Nearshore,Santa Cruz Island,-179
+298,298.1N,34.022835,-119.654481,Nearshore,Santa Cruz Island,-31
+298,298.2N,34.054047,-119.639671,Nearshore,Santa Cruz Island,-90
+299,299.1N,34.035176,-119.693999,Nearshore,Santa Cruz Island,10
+299,299.2N,34.067531,-119.676456,Nearshore,Santa Cruz Island,-88
+300,300.1N,34.050742,-119.734077,Nearshore,Santa Cruz Island,179
+300,300.2N,34.082964,-119.715591,Nearshore,Santa Cruz Island,-89
+301,301.1N,34.062664,-119.779654,Nearshore,Santa Cruz Island,26
+301,301.2N,34.095295,-119.768646,Nearshore,Santa Cruz Island,-90
+302,302.1N,34.100976,-119.821473,Nearshore,Santa Cruz Island,-92
+302,302.2N,34.067661,-119.833305,Nearshore,Santa Cruz Island,192
+303,303.1N,34.076995,-119.870488,Nearshore,Santa Cruz Island,18
+303,303.2N,34.110855,-119.87069,Nearshore,Santa Cruz Island,-97
+327,327.1N,33.481359,-118.572541,Nearshore,Santa Catalina Island,38
+327,327.2N,33.521721,-118.573908,Nearshore,Santa Catalina Island,-493
+328,328.1N,33.480539,-118.609642,Nearshore,Santa Catalina Island,-54
+328,328.2N,33.501471,-118.640393,Nearshore,Santa Catalina Island,-311
+329,329.1N,33.460002,-118.594251,Nearshore,Santa Catalina Island,7
+329,329.2N,33.437033,-118.622772,Nearshore,Santa Catalina Island,-427
+330,330.1N,33.433816,-118.567416,Nearshore,Santa Catalina Island,11
+330,330.2N,33.40981,-118.595655,Nearshore,Santa Catalina Island,-598
+331,331.1N,33.422557,-118.51837,Nearshore,Santa Catalina Island,-9
+331,331.2N,33.397867,-118.543764,Nearshore,Santa Catalina Island,-374
+332,332.1N,33.399431,-118.492245,Nearshore,Santa Catalina Island,-33
+332,332.2N,33.37736,-118.521972,Nearshore,Santa Catalina Island,-206
+333,333.1N,33.358136,-118.492304,Nearshore,Santa Catalina Island,-19
+333,333.2N,33.335904,-118.522348,Nearshore,Santa Catalina Island,-85
+334,334.1N,33.323293,-118.470095,Nearshore,Santa Catalina Island,-50
+334,334.2N,33.299251,-118.49831,Nearshore,Santa Catalina Island,-263
+335,335.1N,33.31582,-118.43314,Nearshore,Santa Catalina Island,186
+335,335.2N,33.284958,-118.442422,Nearshore,Santa Catalina Island,-446
+336,336.1N,33.31325,-118.393192,Nearshore,Santa Catalina Island,-57
+336,336.2N,33.279763,-118.397749,Nearshore,Santa Catalina Island,-717
+337,337.1N,33.303205,-118.351038,Nearshore,Santa Catalina Island,-5
+337,337.2N,33.269754,-118.357541,Nearshore,Santa Catalina Island,-527
+338,338.1N,33.299378,-118.316289,Nearshore,Santa Catalina Island,295
+338,338.2N,33.267801,-118.304896,Nearshore,Santa Catalina Island,-229
+339,339.1N,33.308464,-118.301993,Nearshore,Santa Catalina Island,72
+339,339.2N,33.308122,-118.261527,Nearshore,Santa Catalina Island,-186
+340,340.1N,33.333336,-118.306605,Nearshore,Santa Catalina Island,-56
+340,340.2N,33.35007,-118.270147,Nearshore,Santa Catalina Island,-358
+341,341.1N,33.358873,-118.326163,Nearshore,Santa Catalina Island,-56
+341,341.2N,33.378055,-118.293258,Nearshore,Santa Catalina Island,-360
+342,342.1N,33.384007,-118.355025,Nearshore,Santa Catalina Island,-42
+342,342.2N,33.405032,-118.319137,Nearshore,Santa Catalina Island,-315
+343,343.1N,33.411552,-118.366314,Nearshore,Santa Catalina Island,51
+343,343.2N,33.43221,-118.335137,Nearshore,Santa Catalina Island,-368
+344,344.1N,33.423186,-118.39604,Nearshore,Santa Catalina Island,-128
+344,344.2N,33.453778,-118.373027,Nearshore,Santa Catalina Island,-630
+345,345.1N,33.436967,-118.4345,Nearshore,Santa Catalina Island,-129
+345,345.2N,33.468473,-118.417416,Nearshore,Santa Catalina Island,-664
+346,346.1N,33.454707,-118.483767,Nearshore,Santa Catalina Island,-74
+346,346.2N,33.48501,-118.462914,Nearshore,Santa Catalina Island,-672
+347,347.1N,33.478477,-118.53638,Nearshore,Santa Catalina Island,-3
+347,347.2N,33.507898,-118.515911,Nearshore,Santa Catalina Island,-553

--- a/Doc/estimateBiomass.Rmd
+++ b/Doc/estimateBiomass.Rmd
@@ -134,6 +134,11 @@ The results were generated using R and Rstudio:
 * `r sessionInfo()$R.version$version.string`
 * Last run: `r format(Sys.time(), "%F %T", tz = "America/Los_Angeles", usetz = TRUE)`
 
+Critical analysis settings:
+
+Remove deep nearshore backscatter: **`r rm.deep.nasc`**
+Adjust deep nearshore backscatter: **`r adj.deep.nasc`**
+
 ## Controls and Settings
 
 Processing controls and survey-specific settings are configured here: `here("Doc/settings")`. The settings file is automatically identified based on the name of the directory in which the .Rproj file is stored (in this case, `r here()`). For this analysis, **`r prj.settings`** is used. More information about the settings file is below.  

--- a/Doc/estimateBiomass.Rmd
+++ b/Doc/estimateBiomass.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Estimate CPS biomass from Acoustic-Trawl Surveys"
-author: "Kevin L. Stierhoff (Maintainer), Juan P. Zwolinski, and David A. Demer"
+author: "Kevin L. Stierhoff (Maintainer), Josiah S. Renfree, Juan P. Zwolinski, and David A. Demer"
 date: '`r format(Sys.time(), format = "%F %T", usetz = TRUE)`'
 csl: csl/ices-journal-of-marine-science.csl
 css: css/ast.css
@@ -95,9 +95,9 @@ get.db            <- T # Download data from databases (fast; generally TRUE)
 get.nav           <- T # Download primary vessel nav data from ERDDAP
 get.nav.sd        <- F # Download Saildrone nav data from ERDDAP
 get.nav.sh        <- F # Download NOAA Ship nav data
-copy.files        <- T # Copy data files to local directory 
+copy.files        <- F # Copy data files to local directory 
 process.csv       <- T # Process Echoview files
-save.figs         <- T # Draw new figures and maps
+save.figs         <- F # Draw new figures and maps
 download.hab      <- F # Download habitat map
 process.scs       <- F # Process SCS data 
 
@@ -108,8 +108,8 @@ do.imap           <- T # Create interactive Leaflet map
 save.imap         <- F # Save Leaflet maps
 overwrite.files   <- T # Overwrite files (TRUE if files have changed)
 overwrite.csv     <- T # Overwrite CSV files (TRUE if files have changed)
-process.csv.all   <- T # Process all acoustic backscatter files (F = new files only)
-process.csv.krill <- T # Process krill backscatter data
+process.csv.all   <- F # Process all acoustic backscatter files (F = new files only)
+process.csv.krill <- F # Process krill backscatter data
 process.cufes     <- F # Process CUFES data (no CUFES sampling post-2023)
 process.cal       <- F # Process calibration results
 process.ctd       <- F # Process CTD and UCTD casts
@@ -132,7 +132,7 @@ This report presents results from the **`r survey.name.long` (`r survey.name`)**
 The results were generated using R and Rstudio:  
 
 * `r sessionInfo()$R.version$version.string`
-* Last run: `r session.info[["platform"]]$date`
+* Last run: `r format(Sys.time(), "%F %T", tz = "America/Los_Angeles", usetz = TRUE)`
 
 ## Controls and Settings
 
@@ -8266,8 +8266,189 @@ save(L.abund.table, abund.summ, file = here("Output/abundance_table_all.Rdata"))
 write_csv(abund.summ, here("Output/abundance_table_all.csv"))
 ```
 
+```{r biomass-summ-all,results='asis'}
+# Get survey estimates for all strata
+be.all     <- be %>% 
+  mutate(Region = "Core") %>% 
+  select(Species, Stock, Region, everything()) %>% 
+  filter(Stratum == "All")
+be.all.ns  <- be.ns %>%
+  mutate(Region = "Nearshore") %>%
+  select(Species, Stock, Region, everything()) %>%
+  filter(Stratum == "All")
+be.all.nse <- be.nse %>% 
+  mutate(Region = "NSE") %>% 
+  select(Species, Stock, Region, everything()) %>% 
+  filter(Stratum == "All")
+
+# Summarise biomass for all regions included in the final estimates
+be.all.var <- be.all %>% 
+  bind_rows(be.all.ns) %>%
+  select(Species, Stock, biomass.sd) %>% 
+  group_by(Species, Stock) %>%
+  summarise(biomass.sd = sqrt(sum(biomass.sd^2)))
+
+# Combine core and nearshore biomass
+be.all.summ <- be.all %>% 
+  bind_rows(be.all.ns) %>%
+  group_by(Species, Stock) %>% 
+  select(-Region, -Stratum, -biomass.sd, -biomass.cv) %>% 
+  summarise_all(list(sum)) %>% 
+  left_join(be.all.var) %>% 
+  mutate(biomass.cv = biomass.sd/Biomass*100)
+```
+
+```{r biomass-table-all,results='asis'}
+# Format bootstrap estimate tables
+be.table <- be  %>%
+  rename(Name = Species,
+         Number           = Stratum,
+         Transects        = nTransects,
+         Clusters         = nClusters,
+         Individuals      = nIndiv,
+         "$\\hat{B}$"     = Biomass,
+         SD               = biomass.sd,
+         CV               = biomass.cv,
+         "CI$_{L,95\\%}$" = lower.ci.B,
+         "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+  select(-SD)  
+
+if (exists("be.ns")) {
+  be.table.ns <- be.ns  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+    select(-SD)
+}
+
+if (exists("be.nse")) {
+  be.table.nse <- be.nse  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+    select(-SD)
+}
+
+if (exists("be.os")) {
+  be.table.os <- be.os  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>%
+    select(-SD)  
+}
+
+# Format summary table
+be.table.summ <- be.all.summ %>% 
+  rename(Name = Species,
+         # Number           = Stratum,
+         Transects        = nTransects,
+         Clusters         = nClusters,
+         Individuals      = nIndiv,
+         "$\\hat{B}$"     = Biomass,
+         SD               = biomass.sd,
+         CV               = biomass.cv,
+         "CI$_{L,95\\%}$" = lower.ci.B,
+         "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+  select(-SD)
+``` 
+
 ## Results for anchovy (_Engraulis mordax_)
 ### Northern stock
+#### Biomass estimates
+
+(ref:biomass-anch-n) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the northern subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-anch-n}
+
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Engraulis_mordax_Northern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>%
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>%
+      merge_h(part = "header") %>%
+      align(align = "center",part = "header") %>%
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-anch-n)') %>%
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>%
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density 
 
 (ref:biom-dens-anch-n) Biomass densities of northern stock of Northern Anchovy (_Engraulis mordax_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one anchovy. The gray line represents the vessel track.
 
@@ -8287,7 +8468,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-anch-n) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for the northern stock of Northern Anchovy (_Engraulis mordax_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-anch-n) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for the northern stock of Northern Anchovy (_Engraulis mordax_) in the survey area.
 
 ```{r l-disagg-anch-n,fig.cap='(ref:l-disagg-anch-n)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for anchovy
@@ -8306,7 +8489,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-anch-n) Abundance versus standard length ($L_S$, cm) for the northern stock of Northern Anchovy (_Engraulis mordax_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-anch-n) Abundance versus standard length (cm) for the northern stock of Northern Anchovy (_Engraulis mordax_).
 
 ```{r l-freq-summ-anch-n}
 # Print table for anchovy
@@ -8342,6 +8527,79 @@ if ("Engraulis mordax" %in% unique(abund.summ$Species)) {
 ```
 
 ### Central stock
+#### Biomass estimates
+
+(ref:biomass-anch-c) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the central subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-anch-c}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Engraulis mordax", Stock == "Central") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Engraulis_mordax_Central.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-anch-c)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-anch-c) Biomass densities of central stock of Northern Anchovy (_Engraulis mordax_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one anchovy. The gray line represents the vessel track.
 
@@ -8362,7 +8620,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-anch-c) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for the central stock of Northern Anchovy (_Engraulis mordax_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-anch-c) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for the central stock of Northern Anchovy (_Engraulis mordax_) in the survey area.
 
 ```{r l-disagg-anch-c,fig.cap='(ref:l-disagg-anch-c)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for anchovy
@@ -8381,7 +8641,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-anch-c) Abundance versus standard length ($L_S$, cm) for the central stock of Northern Anchovy (_Engraulis mordax_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-anch-c) Abundance versus standard length (cm) for the central stock of Northern Anchovy (_Engraulis mordax_).
 
 ```{r l-freq-summ-anch-c}
 # Print table for anchovy
@@ -8404,7 +8666,7 @@ if ("Engraulis mordax" %in% unique(abund.summ$Species)) {
       kable(abund.summ.table, booktabs = FALSE,escape = FALSE,longtable = T,
             digits = c(0),
             format.args = list(big.mark = ","),
-            caption = '(ref:l-freq-summ-anch-n)') %>%
+            caption = '(ref:l-freq-summ-anch-c)') %>%
         kable_styling(latex_options = c("striped","repeat_headers")) %>%
         column_spec(1, italic = T) %>% 
         collapse_rows(columns = c(1:2)) %>%
@@ -8417,8 +8679,9 @@ if ("Engraulis mordax" %in% unique(abund.summ$Species)) {
 ```
 
 ### All stocks
+#### Cluster-specific length distributions
 
-(ref:rlf-anchovy) Standard length ($L_S$) frequency distributions of Northern Anchovy (_Engraulis mordax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
+(ref:rlf-anchovy) Standard length frequency distributions of Northern Anchovy (_Engraulis mordax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-anchovy,out.height='100%',fig.pos='H'}
 # Insert relative length frequency plot for anchovy
@@ -8431,6 +8694,79 @@ if (file.exists(here("Figs/fig_cluster_relative_length_frequency_Engraulis morda
 
 ## Results for sardine (_Sardinops sagax_)
 ### Northern stock
+#### Biomass estimates
+
+(ref:biomass-sar-n) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the northern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-sar-n}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Sardinops sagax", Stock == "Northern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Sardinops sagax", Stock == "Northern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Sardinops_sagax_Northern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-sar-n)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-sar-n) Biomass densities of northern stock of Pacific Sardine (_Sardinops sagax_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one sardine. The gray line represents the vessel track.
 
@@ -8451,7 +8787,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-sar-n) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for the northern stock of Pacific Sardine (_Sardinops sagax_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-sar-n) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for the northern stock of Pacific Sardine (_Sardinops sagax_) in the survey area.
 
 ```{r l-disagg-sar-n,fig.cap='(ref:l-disagg-sar-n)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for sardine
@@ -8470,7 +8808,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-sar-n) Abundance versus standard length ($L_S$, cm) for the northern stock of Pacific Sardine (_Sardinops sagax_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-sar-n) Abundance versus standard length (cm) for the northern stock of Pacific Sardine (_Sardinops sagax_).
 
 ```{r l-freq-summ-sar-n}
 # Print table for sardine
@@ -8506,6 +8846,79 @@ if ("Sardinops sagax" %in% unique(abund.summ$Species)) {
 ```
 
 ### Southern stock
+#### Biomass estimates
+
+(ref:biomass-sar-s) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the southern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-sar-s}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Sardinops sagax", Stock == "Southern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Sardinops sagax", Stock == "Southern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Sardinops_sagax_Southern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-sar-s)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-sar-s) Biomass densities of southern stock of Pacific Sardine (_Sardinops sagax_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one sardine. The gray line represents the vessel track.
 
@@ -8525,7 +8938,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-sar-s) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for the southern stock of Pacific Sardine (_Sardinops sagax_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-sar-s) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for the southern stock of Pacific Sardine (_Sardinops sagax_) in the survey area.
 
 ```{r l-disagg-sar-s,fig.cap='(ref:l-disagg-sar-s)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for sardine
@@ -8544,7 +8959,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-sar-s) Abundance versus standard length ($L_S$, cm) for the southern stock of Pacific Sardine (_Sardinops sagax_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-sar-s) Abundance versus standard length (cm) for the southern stock of Pacific Sardine (_Sardinops sagax_).
 
 ```{r l-freq-summ-sar-s}
 # Print table for sardine
@@ -8580,8 +8997,9 @@ if ("Sardinops sagax" %in% unique(abund.summ$Species)) {
 ```
 
 ### All stocks
+#### Cluster-specific length distributions
 
-(ref:rlf-sardine) Standard length ($L_S$) frequency distributions of Pacific Sardine (_Sardinops sagax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
+(ref:rlf-sardine) Standard length frequency distributions of Pacific Sardine (_Sardinops sagax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-sardine,out.height='100%',fig.pos='H'}
 # Insert relative length frequency plot for sardine
@@ -8593,6 +9011,79 @@ if (file.exists(here("Figs/fig_cluster_relative_length_frequency_Sardinops sagax
 ``` 
 
 ## Results for Pacific mackerel (_Scomber japonicus_)  
+#### Biomass estimates
+
+(ref:biomass-mack) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Pacific Mackerel (_Scomber japonicus_) in nearshore survey region. Stratum areas are nmi^2^.
+
+```{r biomass-mack}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Scomber japonicus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Scomber japonicus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Scomber_japonicus_all.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-mack)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-mack) Biomass densities of Pacific mackerel (_Scomber japonicus_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one mackerel The gray line represents the vessel track.
 
@@ -8613,7 +9104,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-mack) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for Pacific mackerel (_Scomber japonicus_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-mack) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for Pacific mackerel (_Scomber japonicus_) in the survey area.
 
 ```{r l-disagg-mack,fig.cap='(ref:l-disagg-mack)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for P. mackerel
@@ -8632,7 +9125,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-mack) Abundance versus standard length ($L_S$, cm) for for Pacific mackerel (_Scomber japonicus_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-mack) Abundance versus standard length (cm) for for Pacific mackerel (_Scomber japonicus_).
 
 ```{r l-freq-summ-mack}
 # Print table for mack mackerel
@@ -8667,6 +9162,8 @@ if ("Scomber japonicus" %in% unique(abund.summ$Species)) {
 }
 ```
 
+#### Cluster-specific length distributions
+
 (ref:rlf-mack) Fork length ($L_F$) frequency distributions of Pacific Mackerel (_Scomber japonicus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-mack,out.height='100%',fig.pos='H'}
@@ -8679,6 +9176,79 @@ if (file.exists(here("Figs/fig_cluster_relative_length_frequency_Scomber japonic
 ``` 
 
 ## Results for Jack Mackerel (_Trachurus symmetricus_)
+#### Biomass estimates
+
+(ref:biomass-jack) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Jack Mackerel (_Trachurus symmetricus_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-jack}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Trachurus symmetricus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Trachurus symmetricus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Trachurus_symmetricus_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-jack)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-jack) Biomass densities of Jack Mackerel (_Trachurus symmetricus_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one jack mackerel. The gray line represents the vessel track.
 
@@ -8699,7 +9269,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-jack) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for Jack Mackerel (_Trachurus symmetricus_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-jack) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for Jack Mackerel (_Trachurus symmetricus_) in the survey area.
 
 ```{r l-disagg-jack,fig.cap='(ref:l-disagg-jack)',out.height='100%',fig.pos='H'}
 if (combine.regions) {
@@ -8717,7 +9289,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-jack) Abundance versus standard length ($L_S$, cm) for for Jack Mackerel (_Trachurus symmetricus_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-jack) Abundance versus standard length (cm) for for Jack Mackerel (_Trachurus symmetricus_).
 
 ```{r l-freq-summ-jack}
 # Print table for jack mackerel
@@ -8752,6 +9326,8 @@ if ("Trachurus symmetricus" %in% unique(abund.summ$Species)) {
 }
 ```
 
+#### Cluster-specific length distributions
+
 (ref:rlf-jack) Fork length ($L_F$) frequency distributions of Jack Mackerel (_Trachurus symmetricus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-jack,out.height='100%',fig.pos='H'}
@@ -8764,6 +9340,79 @@ if (file.exists(here("Figs/fig_cluster_relative_length_frequency_Trachurus symme
 ``` 
 
 ## Results for Pacific herring (_Clupea pallasii_)
+#### Biomass estimates
+
+(ref:biomass-her) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Pacific Herring (_Clupea pallasii_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-her}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Clupea pallasii") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Clupea pallasii") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Clupea_pallasii_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-her)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-her) Biomass densities of Pacific herring (_Clupea pallasii_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one herring. The gray line represents the vessel track.
 
@@ -8783,7 +9432,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-her) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for Pacific herring (_Clupea pallasii_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-her) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for Pacific herring (_Clupea pallasii_) in the survey area.
 
 ```{r l-disagg-her,fig.cap='(ref:l-disagg-her)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for herring
@@ -8802,7 +9453,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-her) Abundance versus standard length ($L_S$, cm) for for Pacific herring (_Clupea pallasii_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-her) Abundance versus standard length (cm) for for Pacific herring (_Clupea pallasii_).
 
 ```{r l-freq-summ-her}
 # Print table for jack mackerel
@@ -8837,7 +9490,9 @@ if ("Clupea pallasii" %in% unique(abund.summ$Species)) {
 }
 ```
 
-(ref:rlf-her) Standard length ($L_S$) frequency distributions of Pacific herring (_Clupea pallasii_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
+#### Cluster-specific length distributions
+
+(ref:rlf-her) Standard length frequency distributions of Pacific herring (_Clupea pallasii_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-her,out.height='100%',fig.pos='H'}
 # Insert relative length frequency plot for herring
@@ -8849,6 +9504,79 @@ if (file.exists(here("Figs/fig_cluster_relative_length_frequency_Clupea pallasii
 ```
 
 ## Results for round herring (_Etrumeus acuminatus_)
+#### Biomass estimates
+
+(ref:biomass-rher) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Round Herring (_Etrumeus acuminatus_) in the core  and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-rher}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Etrumeus acuminatus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Etrumeus acuminatus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Etrumeus_acuminatus_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-rher)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+#### Biomass density
 
 (ref:biom-dens-rher) Biomass densities of round herring (_Etrumeus acuminatus_), per strata, throughout the survey region. The blue numbers represent the locations of trawl clusters with at least one herring. The gray line represents the vessel track.
 
@@ -8868,7 +9596,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-disagg-rher) Abundance versus standard length ($L_S$, upper panel) and biomass (t) versus $L_S$ (lower panel) for round herring (_Etrumeus acuminatus_) in the survey area.
+#### Length-disaggregated abundance
+
+(ref:l-disagg-rher) Abundance versus standard length (upper panel) and biomass (t) versus standard length (lower panel) for round herring (_Etrumeus acuminatus_) in the survey area.
 
 ```{r l-disagg-rher,fig.cap='(ref:l-disagg-rher)',out.height='100%',fig.pos='H'}
 # Insert disaggregated abundance plots for herring
@@ -8887,7 +9617,9 @@ if (combine.regions) {
 }
 ```
 
-(ref:l-freq-summ-rher) Abundance versus standard length ($L_S$, cm) for for round herring (_Etrumeus acuminatus_).
+#### Abundande-by-length table
+
+(ref:l-freq-summ-rher) Abundance versus standard length (cm) for for round herring (_Etrumeus acuminatus_).
 
 ```{r l-freq-summ-rher}
 # Print table for round herring
@@ -8910,7 +9642,7 @@ if ("Etrumeus acuminatus" %in% unique(abund.summ$Species)) {
       kable(abund.summ.table, booktabs = FALSE,escape = FALSE,longtable = T,
             digits = c(0),
             format.args = list(big.mark = ","),
-            caption = '(ref:l-freq-summ-her)') %>%
+            caption = '(ref:l-freq-summ-rher)') %>%
         kable_styling(latex_options = c("striped","repeat_headers")) %>%
         column_spec(1, italic = T) %>% 
         collapse_rows(columns = c(1:2)) %>%
@@ -8922,7 +9654,9 @@ if ("Etrumeus acuminatus" %in% unique(abund.summ$Species)) {
 }
 ```
 
-(ref:rlf-rher) Standard length ($L_S$) frequency distributions of round herring (_Etrumeus acuminatus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
+#### Cluster-specific length distributions
+
+(ref:rlf-rher) Standard length frequency distributions of round herring (_Etrumeus acuminatus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum and across all strata (i.e., for the entire survey).
 
 ```{r rlf-rher,out.height='100%',fig.pos='H'}
 # Insert relative length frequency plot for round herring

--- a/Doc/reportBiomass_2506SH.Rmd
+++ b/Doc/reportBiomass_2506SH.Rmd
@@ -1,0 +1,2767 @@
+---
+# title: "DISTRIBUTION, BIOMASS, AND DEMOGRAPHICS OF COASTAL PELAGIC FISHES IN THE CALIFORNIA CURRENT ECOSYSTEM DURING SUMMER 2025 BASED ON ACOUSTIC-TRAWL SAMPLING"
+# author:
+# date: '`r format(Sys.time(), format = "%F %T", tz = "UTC", usetz = TRUE)`'
+output:
+  bookdown::pdf_document2:
+    includes:
+      in_header: yaml/header_final.tex
+    toc: false
+    toc_depth: 3
+    number_sections: yes
+  bookdown::html_document2:
+    toc: yes
+    toc_float: yes
+  bookdown::word_document2:
+    reference_docx: template/report_template_Rmarkdown.docx
+    toc: false
+    toc_depth: 3
+    pandoc_args:
+    - --filter
+    - yaml/pandoc-newpage-filter.R
+  word_document:
+    toc: yes
+    toc_depth: '3'
+  pdf_document:
+    toc: false
+    toc_depth: '3'
+csl: csl/ices-journal-of-marine-science.csl
+bibliography: bib/ast_bib.bib
+css: css/ast.css
+always_allow_html: yes
+linkcolor: blue
+---
+
+```{r load-libraries,echo=F,error=F,message=F,warning=F}
+# Install and load pacman (library management package)
+if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
+
+# Install and load required packages from CRAN ---------------------------------
+pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate,knitr,here,
+               png,devtools,forcats,jpeg,bookdown,magick,
+               odbc,cowplot,mapview,fs,patchwork,gt)
+
+# Install and load required packages from Github -------------------------------
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
+# kableExtra - for R >= 4.3.0
+pacman::p_load_gh("kupietz/kableExtra")
+
+# set system time zone to UTC
+Sys.setenv(tz = "UTC")
+
+# determines method of table generation (whether kable or flextable) for best formatting
+doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')
+if (is.null(doc.type)) {doc.type <- "html"}
+
+# global knitr chunk options
+knitr::opts_chunk$set(echo = F, warning = F, message = F,
+                      knitr.kable.NA = "-",
+                      fig.align = "center",
+                      dev = "png", dev.args = list(type = "cairo"))
+
+# Set options for NA values in knitr::kable
+options(knitr.kable.NA = '-')
+
+# determine global knitr table format
+if (doc.type == "latex") {
+  knitr.format <- "latex"
+} else {
+  knitr.format <- "html" 
+}
+
+# global pander options
+panderOptions('table.style','rmarkdown'); panderOptions('table.split.table', Inf); panderOptions('digits', 6);
+panderOptions('round', 6); panderOptions('keep.trailing.zeros', T); panderOptions('missing', "")
+```
+
+```{r loop-controls}
+# User-defined loop controls
+combine.regions  <- T # Combine core and nearshore biomass plots
+plot.time.series <- T # Plot biomass time series 
+get.db           <- T # Query biomass estimates from AST database
+process.cal      <- F # Process, format, and plot echosounder calibration results
+save.figs        <- T # Save figures
+```
+
+```{r user-input, include=FALSE}
+# Get project name from directory
+prj.name <- last(unlist(str_split(here(),"/")))
+
+# Survey information files ------------------------------------------------------
+settings.files <- dir(here("Doc/settings"))
+prj.settings <- settings.files[str_detect(settings.files, paste0("settings_", prj.name, ".R"))]
+source(here("Doc/settings", prj.settings))
+
+# Output files ------------------------------------------------------------------
+prj.output <- settings.files[str_detect(settings.files, paste0("output_", prj.name, ".R"))]
+source(here("Doc/settings", prj.output))
+```  
+
+```{r stock-specific-biomasses}
+# Extract stock-specific data, for ease of reporting in text
+## Northern Anchovy
+be.anch.n <- be %>% 
+  filter(Species == "Engraulis mordax", Stock == "Northern", Stratum != "All")
+be.anch.c <- be %>% 
+  filter(Species == "Engraulis mordax", Stock == "Central", Stratum != "All")
+## Pacific Sardine
+be.sar.n <- be.all.summ %>% 
+  filter(Species == "Sardinops sagax", Stock == "Northern", Stratum != "All")
+be.sar.s <- be %>% 
+  filter(Species == "Sardinops sagax", Stock == "Southern", Stratum != "All")
+## Jack Mackerel
+be.jack <- be %>% 
+  filter(Species == "Trachurus symmetricus", Stock == "All", Stratum != "All")
+## Pacific Mackerel
+be.mack <- be %>% 
+  filter(Species == "Scomber japonicus", Stock == "All", Stratum != "All")
+## Pacific Herring
+be.her <- be %>% 
+  filter(Species == "Clupea pallasii", Stock == "All", Stratum != "All")
+## Round Herring
+be.rher <- be %>% 
+  filter(Species == "Etrumeus acuminatus", Stock == "All", Stratum != "All")
+```
+
+```{r process-biomass-ts}
+if (plot.time.series) {
+  source(here("Code/plot_BiomassTimeSeries.R"))
+} else {
+  if (file.exists(here("Output/biomass_timeseries_final.Rdata"))) {
+    load(here("Output/biomass_timeseries_final.Rdata"))  
+  } else {
+    print("No time series data available")
+  }
+}
+```
+
+```{r time-series-percentages}
+# Summarize percent total biomass for CS anchovy 
+biomass.pct.anch.c <- biomass.spp.summ %>% 
+  filter(species == "Engraulis mordax", stock == "Central")
+# Summarize percent total biomass for NS anchovy
+biomass.pct.anch.n <- biomass.spp.summ %>% 
+  filter(species == "Engraulis mordax", stock == "Northern")
+# Summarize percent total biomass for NS sardine
+biomass.pct.sar.n <- biomass.spp.summ %>% 
+  filter(species == "Sardinops sagax", stock == "Northern", year >= 2015)
+# Summarize percent total biomass for SS sardine
+biomass.pct.sar.s <- biomass.spp.summ %>% 
+  filter(species == "Sardinops sagax", stock == "Southern", year >= 2015)
+# Summarize percent total biomass for P. mackerel
+biomass.pct.mack <- biomass.spp.summ %>% 
+  filter(species == "Scomber japonicus") %>% 
+  arrange(year)
+# Summarize percent total biomass for Jack mackerel
+biomass.pct.jack <- biomass.spp.summ %>% 
+  filter(species == "Trachurus symmetricus") %>% 
+  arrange(year)
+# Summarize percent total biomass for P. herring
+biomass.pct.her <- biomass.spp.summ %>% 
+  filter(species == "Clupea pallasii") %>% 
+  arrange(year)
+# Summarize percent total biomass for P. herring
+biomass.pct.rher <- biomass.spp.summ %>% 
+  filter(species == "Etrumeus acuminatus") %>% 
+  arrange(year)
+```
+
+\pagenumbering{gobble}
+
+**DISTRIBUTION, BIOMASS, AND DEMOGRAPHICS OF COASTAL PELAGIC FISHES IN THE CALIFORNIA CURRENT ECOSYSTEM DURING SUMMER 2024 BASED ON ACOUSTIC-TRAWL SAMPLING**
+
+Kevin L. Stierhoff^1^, Josiah S. Renfree^1^, and Juan P. Zwolinski^1,2^  
+
+^1^Fisheries Resources Division  
+Southwest Fisheries Science Center  
+NOAA-National Marine Fisheries Service  
+8901 La Jolla Shores Dr.  
+La Jolla, CA 92037, USA  
+
+^2^University of California, Santa Cruz   
+The Cooperative Institute for Marine, Earth and Atmospheric Systems (CIMEAS)  
+1156 High St  
+Santa Cruz, CA 95064, USA  
+
+\newpage
+
+\tableofcontents
+
+\newpage
+
+\listoftables
+
+\listoffigures
+
+\newpage
+
+\pagenumbering{arabic}
+
+# Executive Summary {-}
+
+This report provides:  1) a detailed description of the acoustic-trawl method (ATM) used by NOAA's Southwest Fisheries Science Center for direct assessments of the dominant coastal pelagic species (CPS; i.e.:  Pacific Sardine _Sardinops sagax_, Northern Anchovy _Engraulis mordax_, Pacific Mackerel _Scomber japonicus_, Jack Mackerel _Trachurus symmetricus_, Pacific Herring _Clupea pallasii_, and Round Herring _Etrumeus acuminatus_) in the California Current Ecosystem off the west coast of the United States (U.S.) and portions of Canada and Baja CA, Mexico; 2) a description of the new multi-function trawl (MFT) system and sea trials conducted during five days at sea (DAS) at the beginning of the survey; and 3) estimates of the biomasses, distributions, and demographics of those CPS encountered in the survey area between `r survey.start` and `r survey.end` `r survey.year`.  
+
+The core survey region, which was sampled by NOAA ship _`r survey.vessel.long`_ (hereafter, _`r survey.vessel`_), spanned most of the continental shelf between `r survey.landmark.s`, CA and `r survey.landmark.n`. Planned transects were oriented approximately perpendicular to the coast, from the shallowest navigable depth (~20 m) to a distance of 35 nmi offshore or, if farther, to the 1,000 ftm (~1830 m) isobath. In the SCB, transects in the core region were extended to approximately 100 nmi.      
+
+Because navigation by _`r survey.vessel`_ in water shallower than ~20 m was deemed inefficient, unsafe, or both, fishing vessels _Long Beach Carnage_ and _Lisa Marie_ sampled CPS in the nearshore region, along 2.5 to 5 nmi-long transects spaced 5 to 7 nmi-apart off the mainland coast of the U.S., between San Diego and Cape Flattery, as well as around Santa Cruz and Santa Catalina Islands in the Southern CA Bight. In the nearshore region, and due to sparse purse seine sampling along portions of the coast, the acoustically-sampled CPS were apportioned using the species compositions and length distributions from either daytime purse-seine sets by _Long Beach Carnage_ or _Lisa Marie_ or nighttime trawl from _`r survey.vessel`_, whichever was closest in space.  
+
+The biomasses (metric tons, t), distributions, and demographics for each species and subpopulation are for the survey area and period, and therefore may not represent their entire population or subpopulation. Sampling was also conducted in the core and nearshore regions off Baja CA by Instituto Mexicano de Investigación en Pesca y Acuacultura Sustentables (IMIPAS, formerly INAPESCA), but the estimates in this report are only derived from data collected by  _`r survey.vessel`_, _Long Beach Carnage_, and _Lisa Marie_.  
+
+The estimated biomass of the northern subpopulation of Northern Anchovy was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=2)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=4)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=2)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=1)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=2)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"] + be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"]))*100,big.mark=",",digits=2)`% of the total biomass. The northern subpopulation was sparsely distributed between Astoria and Cape Flattery, and the distribution of standard lengths ($L_S$) ranged from `r length.summ$L.min[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Northern"]` to `r length.summ$L.max[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Northern"]` cm with a mode at 15 cm in both regions.
+
+The estimated biomass of the central subpopulation of Northern Anchovy was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=4)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=4)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=4)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"] / (be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"] + be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"]))*100,big.mark=",",digits=2)`% of the total biomass. The central subpopulation ranged from approximately San Diego to San Francisco, and the distribution of $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Central"]` to `r length.summ$L.max[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Central"]` cm with modes at 6 and 13 cm in the core region and at 8 and 13 cm in the nearshore region. The estimated biomass of the central subpopulation of Northern Anchovy, which has comprised the majority of CPS biomass since 2015, decreased `r prettyNum((1-(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"]/biomass.pct.anch.c$biomass[biomass.pct.anch.c$year == 2023]))*100,,big.mark=",",digits=2)`% from the `r prettyNum(biomass.pct.anch.c$biomass[biomass.pct.anch.c$year == 2023],big.mark=",",digits=5)` t estimated in summer 2023 [@Stierhoff2024].
+
+The estimated biomass of the northern subpopulation of Pacific Sardine was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=2)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=1)`%) and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"] + be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"]))*100,big.mark=",",digits=3)`% of the total biomass. The northern subpopulation was observed between Pt. Conception and Monterey, and between Astoria and Cape Flattery in the core region, and in the nearshore region was mostly observed between Pt. Conception and San Francisco. The distribution of $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Northern"]` to `r length.summ$L.max[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Northern"]` cm with modes at 9 and 17 cm in the core region and at 19 cm in the nearshore region. These results were included in the update assessment used to provide a biomass estimate for harvest specifications of the northern subpopulation of Pacific Sardine during the 2025-2026 fishing year [@AllenAkselrud2025a]. Japanese Sardine (_Sardinops melanosticta_) were present in the survey area during the survey period [@Longo2025], but all sardine were assumed to be _S. sagax_ for the purpose of estimating biomass. Therefore, biomass estimates for both the northern and southern subpopulations may be subject to change.  
+
+<!-- **Note that the biomass estimates of the northern and southern subpopulations of Pacific Sardine include an unknown proportion of Japanese Sardine (_Sardinops melanosticta_), and may be subjected to future revisions [@Longo2025].** -->
+
+The estimated biomass of the southern subpopulation of Pacific Sardine in the surveyed area was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=4)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"] + be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"]))*100,big.mark=",",digits=2)`% of the total biomass. The southern subpopulation in this survey was observed off central Baja CA and throughout the SCB, but these results do not include biomass observed in areas surveyed independently by IMIPAS. The distribution of $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Southern"]` to `r length.summ$L.max[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Southern"]` cm with modes at 6 and 19 cm in the core region and modes at 9 and 15 cm in the nearshore region.  
+
+The estimated biomass of Pacific Mackerel was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'] + be.all$Biomass[be.all$Species == 'Scomber japonicus']))*100,big.mark=",",digits=2)`% of the total biomass. Pacific Mackerel were observed in the core and nearshore regions in the SCB, off San Francisco, and off central OR. The distribution of fork lengths ($L_F$) ranged from `r length.summ$L.min[length.summ$scientificName == 'Scomber japonicus']` to `r length.summ$L.max[length.summ$scientificName == 'Scomber japonicus']` cm with modes at 8, 17, and 37 cm in the core region and 22 and 41 cm in the nearshore region.
+
+The estimated biomass of Jack Mackerel was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%). In the core region, the biomass was `r  prettyNum(be.all$Biomass[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=4)` t (CI~95%~ = `r  prettyNum(be.all$lower.ci.B[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'] + be.all$Biomass[be.all$Species == 'Trachurus symmetricus']))*100,big.mark=",",digits=2)`% of the total biomass. Jack Mackerel were observed throughout the survey area, but were most abundant between Cape Mendocino and Cape Scott, Vancouver Island in the core region and between Cape Mendocino and Astoria in the nearshore region. The distribution of $L_F$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Trachurus symmetricus']` to `r length.summ$L.max[length.summ$scientificName == 'Trachurus symmetricus']` cm with modes at 4, 12, and 41 cm in the core region and at 4 cm in the nearshore region.  
+
+The total estimated biomass of Pacific Herring was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'] / (be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'] + be.all$Biomass[be.all$Species == 'Clupea pallasii']))*100,big.mark=",",digits=2)`% of the total biomass. Pacific Herring were observed from approximately Florence, OR to central Vancouver Island in the core region, and between San Francisco and Cape Flattery in the nearshore region. The distribution of $L_F$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Clupea pallasii']` to `r length.summ$L.max[length.summ$scientificName == 'Clupea pallasii']` cm, with modes at 9, 17, and 22 cm in the core region and 9 and 16 cm in the nearshore region.  
+
+The total estimated biomass of Round Herring was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)`%). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)`%), and in the nearshore region the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)`%), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'] + be.all$Biomass[be.all$Species == 'Etrumeus acuminatus']))*100,big.mark=",",digits=2)`% of the total biomass. Round Herring were observed between Punta Eugenia to El Rosario off Baja CA, and near San Nicolas Island, Santa Catalina Island, and Long Beach in the SCB. The distribution of $L_F$ ranged from 2 cm, with modes at 16, 23, and 26 cm in the core region; all lengths were 2-4 cm in the nearshore region.  
+
+<!-- `r length.summ$L.min[length.summ$scientificName == 'Etrumeus acuminatus']` to `r length.summ$L.max[length.summ$scientificName == 'Etrumeus acuminatus']` -->
+
+The total estimated biomass of `r num2words(nrow(be.all.summ))` populations or subpopulations of `r num2words(n_distinct(be.all.summ$Species))` coastal pelagic species within the survey area was `r prettyNum(sum(be.all.summ$Biomass), big.mark=",", digits = 5)` t. Of this, `r round(be.all.summ$Biomass[be.all$Species == "Engraulis mordax" & be.all.summ$Stock == "Central"]/sum(be.all.summ$Biomass)*100)`% (`r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Central"], big.mark=",", digits = 5)` t) was from the central subpopulation of Northern Anchovy and `r round(be.all.summ$Biomass[be.all$Species == "Trachurus symmetricus" & be.all.summ$Stock == "All"]/sum(be.all.summ$Biomass)*100)`% (`r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Trachurus symmetricus" & be.all.summ$Stock == "All"], big.mark=",", digits = 5)` t) was from Jack Mackerel. Proportions of other subpopulations, in decreasing order, were: northern subpopulation of Pacific Sardine (`r round(be.all.summ$Biomass[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Northern"]/sum(be.all.summ$Biomass)*100, 1)`%), Pacific Herring (`r round(be.all.summ$Biomass[be.all.summ$Species == "Clupea pallasii" & be.all.summ$Stock == "All"]/sum(be.all.summ$Biomass)*100, 1)`%), southern subpopulation of Pacific Sardine (`r round(be.all.summ$Biomass[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Southern"]/sum(be.all.summ$Biomass)*100)`%), Pacific Mackerel (`r round(be.all.summ$Biomass[be.all.summ$Species == "Scomber japonicus" & be.all.summ$Stock == "All"]/sum(be.all.summ$Biomass)*100, 1)`%), Round Herring (`r round(be.all.summ$Biomass[be.all.summ$Species == "Etrumeus acuminatus" & be.all.summ$Stock == "All"]/sum(be.all.summ$Biomass)*100, 1)`%), and northern subpopulation of Northern Anchovy (`r round(be.all.summ$Biomass[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Northern"]/sum(be.all.summ$Biomass)*100, 2)`%).  
+
+\newpage
+
+# Introduction {#introduction}  
+
+In the California Current Ecosystem (CCE), multiple coastal pelagic fish species (CPS; i.e.:  Pacific Sardine _Sardinops sagax_, Northern Anchovy _Engraulis mordax_, Jack Mackerel _Trachurus symmetricus_, Pacific Mackerel _Scomber japonicus_, and Pacific Herring _Clupea pallasii_) comprise the bulk of the forage fish assemblage. The term CPS is used here to refer to any of the above-mentioned species, which are a subset of the CPS assemblage listed in the Pacific Fishery Management Council’s CPS Fishery Management Plan^[https://www.pcouncil.org/documents/2023/06/coastal-pelagic-species-fishery-management-plan.pdf/]. These populations, which can change by an order of magnitude within a few years, represent important prey for marine mammals, birds, and larger migratory fishes [@Field2001], and some are targets of commercial fisheries.  
+
+During summer and fall, the northern subpopulation of Pacific Sardine typically migrates north to feed in the productive coastal upwelling off OR, WA, and Vancouver Island [@Zwolinski2012, and references therein, **Fig. \@ref(fig:sardine-distribution)**]. In synchrony, but separately, the southern subpopulation of Pacific Sardine migrates from Northern Baja CA, Mexico to the Southern CA Bight (SCB) [@Smith2005]. The predominantly piscivorous adult Pacific and Jack Mackerels also migrate north in summer, but go farther offshore to feed [@Zwolinski2014 and references therein]. In the winter and spring, the northern subpopulation of Pacific Sardine typically migrates south  to its spawning grounds, generally off Central and Southern CA [@Demer2012] and occasionally off OR and WA [@Lo2011]. These migrations vary in extent with population size, fish age and length, and oceanographic conditions [@Zwolinski2012]. The transition zone chlorophyll front [TZCF, @Polovina2001] may delineate the offshore and southern limit of both northern subpopulation Pacific Sardine and Pacific Mackerel habitat [e.g., @Demer2012; @Zwolinski2012], and juveniles may have nursery areas in the SCB, downstream of upwelling regions. In contrast, Northern Anchovy spawn predominantly during winter and closer to the coast where seasonal down-welling increases retention of their eggs and larvae [@Bakun1982]. Pacific Herring spawn during spring and early summer in intertidal beach areas [@Love1996]. The northern subpopulation of Northern Anchovy is located off WA and OR and the central subpopulation is located off Central and Southern CA and northern Baja CA. Whether a species migrates or remains in an area depends on its reproductive and feeding behaviors, affinity to certain oceanographic or seabed habitats, and its population size.  
+
+Acoustic-trawl method (ATM) surveys, which combine information collected with echosounders and nets, were introduced to the CCE more than 50 years ago to survey CPS off the west coast of the United States (U.S.) [@Mais1974;@Mais1977;@Smith1978]. Following a two-decade hiatus, the ATM was reintroduced in the CCE in spring 2006 to sample the then-abundant Pacific Sardine population [@Cutter2008]. Since then, this sampling effort has continued and expanded through annual or semi-annual surveys [@Zwolinski2014; @Demer2012]. Beginning in 2011, the ATM estimates of Pacific Sardine abundance, age structure, and distribution have been incorporated in the annual assessments of the northern subpopulation [@Hill2017; @Kuriyama2020; @Kuriyama2022b]. ATM estimates are also used in assessments of Pacific Mackerel [@Crone2015; @Crone2019] and the central subpopulation of Northern Anchovy [@Kuriyama2022a]. Additionally, ATM survey results have yielded estimated abundances, demographics, and distributions of epipelagic and semi-demersal fishes [e.g., @Swartzman1997; @Williams2013; @Zwolinski2014] and zooplankton [@Hewitt2000].  
+
+This document, and references herein, describes in detail the ATM as presently used by NOAA's Southwest Fisheries Science Center (SWFSC) to survey the distributions, abundances, biomasses, and demographics of CPS and their oceanographic environments [e.g., @Cutter2008; @Demer2012; @Zwolinski2014]. In general terms, the contemporary ATM combines information from satellite-sensed oceanographic conditions, multifrequency echosounders, probe-sampled oceanographic conditions, trawl-net catches of juvenile and adult CPS, and sometimes pumped samples of fish eggs. The summer survey area spans the continental shelf and adjacent waters to the 1000-fathom isobath off the west coast of the U.S., is expanded to encompass the potential habitat of the northern subpopulation of Pacific Sardine (**Fig. \@ref(fig:sardine-distribution)**), and as time permits, further expanded to encompass as much of the potential habitat as possible for other CPS present over the shelf along the west coasts of Canada and Baja CA.   
+
+Along transects in the survey area, multi-frequency split-beam echosounders transmit sound pulses downward beneath the ship and receive echoes from animals and the seabed in the path of the sound waves. Measurements of sound speed and absorption from conductivity-temperature-depth (CTD) probes allow accurate compensation of these echoes for propagation losses. The calibrated echo intensities, normalized to the range-dependent observational volume, provide indications of the target type and behavior [e.g., @Demer2009].  
+
+(ref:sardine-distribution) Conceptual spring (shaded region) and summer (hashed region) distributions of potential habitat for the northern subpopulation of Pacific Sardine along the west coasts of Mexico, the United States, and Canada. The dashed and dotted lines represent, respectively, the approximate summer and spring positions of the 0.2 mg m^–3^ chlorophyll-a concentration isoline. This isoline appears to oscillate in synchrony with the transition zone chlorophyll front [TZCF, @Polovina2001] and the offshore limit of the northern subpopulation Pacific Sardine potential habitat [@Zwolinski2011]. Mackerels are found within and on the edge of the same oceanographic  habitat [e.g., @Demer2012; @Zwolinski2012]. The TZCF may delineate the offshore and southern limit of both northern subpopulation Pacific Sardine and Pacific Mackerel distributions, and juveniles may have nursery areas in the SCB, downstream of upwelling regions.
+
+```{r sardine-distribution,fig.cap='(ref:sardine-distribution)',out.height='6in',fig.pos='H'}
+include_graphics(here("Images/img_survey_region.png"))  
+```  
+
+\newpage  
+
+Echoes from marine organisms are a function of their body composition, shape, and size relative to the sensing-sound wavelength, and their orientation relative to the incident sound waves [@Cutter2009;@Demer2009;@Renfree2009]. Variations in echo intensity across frequencies, known as echo spectra, indicate the taxonomic groups contributing to the echoes. The CPS, with highly reflective swim bladders, create high intensity echoes of sound pulses at all echosounder frequencies [e.g., @Conti2003]. In contrast, krill, with acoustic properties closer to those of the surrounding seawater, produce lower intensity echoes, particularly at lower frequencies [e.g., @Demer2003]. The echo energy attributed to CPS, based on empirical echo spectra [@Demer2012], are apportioned to species using trawl-catch proportions [@Zwolinski2014].  
+
+Animal densities are estimated by dividing the vertically summed area-backscattering coefficients attributed to a species by their average echo intensity, i.e., the mean backscattering cross-section, from animals of that species [e.g., @Demer2012]. Transects with similar densities and transect spacings are grouped into post-sampling strata that mimic the natural patchiness of the target species [e.g., @Zwolinski2014]. Estimates of abundance are obtained by multiplying the mean densities in the stratum by the respective stratum areas [@Demer2012]. The associated sampling variance is calculated using non-parametric bootstrap of the mean transect densities. The total abundance estimate in the survey area is the sum of abundances in all strata. Similarly, the total variance estimate is the sum of the variance in each stratum.  
+
+The primary objectives of the SWFSC’s ATM surveys are to survey the distributions, abundances, and demographics of CPS, and their abiotic environments in the CCE. Typically, summer surveys are conducted during 50-90 days-at-sea (DAS) between June and October. In summer, the ATM surveys also include the northern subpopulation of Northern Anchovy and Pacific Herring. When they occur, spring surveys are conducted during 25-40 DAS between March and May and focus primarily on the northern subpopulation of Pacific Sardine and the central subpopulation of Northern Anchovy. During spring and summer, biomasses are also estimated for other CPS (e.g., Pacific Mackerel, Jack Mackerel, and Round Herring) present in the survey area.  
+
+In `r tolower(survey.season)` `r survey.year`, the ATM survey was conducted by _`r survey.vessel`_ from `r survey.landmark.s` to `r survey.landmark.n`. From San Diego to Cape Flattery, sampling from fishing vessels _Lisa Marie_ and _Long Beach Carnage_ was used to estimate the biomasses of CPS in the nearshore regions, where sampling by _`r survey.vessel`_ was not possible or safe. 
+
+Presented here are:  1) a detailed description of the ATM used to survey CPS in the California Current Ecosystem (CCE) off the west coast of the U.S.; and 2) estimates of the abundances, biomasses, spatial distributions, and demographics of CPS, specifically the northern and southern subpopulations of Pacific Sardine, the central and northern subpopulations of Northern Anchovy, Pacific Mackerel, Jack Mackerel, Pacific Herring, and Round Herring for the core and nearshore survey regions in which they were sampled. A complementary survey off Baja CA by IMIPAS used approximately the same sampling protocol. Data from that survey, including biomass estimates for CPS in those core and nearshore regions, are reported elsewhere [@MartinezMagana2025].  
+
+The SWFSC's survey was conducted with the approval of the Secretaria de Relaciones Exteriores (SRE, Diplomatic note UAN0731/2024), the Instituto Nacional de Estadística y Geografía (INEGI; Authorization: LIG0032024, through official letter 400./67/2024), Unidad de Planeación y Coordinación Estratégica de la Secretaría de Marina (SEMAR; Letter no DAI-1305-24), Unidad Coordinadora de Asuntos Internacionales (UCAI) de la Secretaría de Medio Ambiente y Recursos Naturales (SEMARNAT; Letter UCAI/01210/2024), Universidad Nacional Autónoma de México (UNAM; Letter ICML/DIR/182/2024), Unidad de Concesiones y Servicios del Instituto Federal de Telecomunicaciones (IFT; Letter IFT/223/UCS/01962/2024), and the Comisión Nacional de Acuacultura y Pesca (CONAPESCA; Permit: PPFE/DGPPE.04357-210524).  
+
+\newpage
+
+# Methods {#methods}
+## Sampling {#methods-data-collection}
+### Design {#methods-survey-design}  
+
+The `r tolower(survey.season)` `r survey.year` survey was conducted principally using _`r survey.vessel`_, but was augmented with nearshore acoustic and purse-seine sampling by two fishing vessels, _Long Beach Carnage_ and _Lisa Marie_. The sampling domain between `r survey.landmark.s` and `r survey.landmark.n` was defined by the conceptual distribution of potential habitat for the northern subpopulation of Pacific Sardine in summer (**Fig. \@ref(fig:sardine-distribution)**), but also encompassed an unknown portion of the anticipated distributions of the southern subpopulation of Pacific Sardine, the central and northern subpopulations of Northern Anchovy, Pacific Mackerel, Jack Mackerel, Pacific Herring, and Round Herring populations off the west coasts of the U.S., Mexico, and Canada. East to west, the sampling domain extended from the coast to at least the 1,000 ftm (~1830 m) isobath (**Fig. \@ref(fig:survey-plan)**). Considering the expected distribution of the target species, and the available ship time (`r survey.das` days at sea, DAS), the primary objective was to estimate the biomasses, spatial distributions, and demographics of the northern subpopulation of Pacific Sardine and the northern and central subpopulations of Northern Anchovy, whose expected distributions were encompassed by the survey region. Secondary objectives were to estimate the biomasses, spatial distributions, and demographics of the southern subpopulation of Pacific Sardine, Pacific Mackerel, Jack Mackerel, Pacific Herring, and Round Herring, since their expected distributions extend beyond the planned survey region.  
+
+The planned core region transects were perpendicular to the coast, extending from the shallowest navigable depth (~20 m) to either a distance of 35 nmi or, where farther, to the 1,000 ftm isobath (**Fig. \@ref(fig:survey-plan)**). Compulsory transects were spaced 10 nmi apart in U.S. waters, and 20 nmi apart off Baja CA and Vancouver Is. The length of compulsory transects was shortened to 30 nmi off Baja CA, and adaptive transects, which are sampled only when CPS were observed along compulsory transects, were spaced 20 nmi apart off Vancouver Island. When CPS were observed within the westernmost 3 nmi of a transect, that transect and the next one to the north were extended in 5-nmi increments until no CPS were observed in the last 3 nmi of the extension, to a maximum extension of 50 nmi. In `r tolower(survey.season)` `r survey.year`, transects were sampled south-to-north to coordinate sampling with the CPS survey conducted by Instituto Mexicano de Investigación en Pesca y Acuacultura Sustentables (IMIPAS, formerly INAPESCA) aboard R/V _Jorge Carranza Fraser_.  
+
+To estimate the abundances and biomasses of CPS in the nearshore region between San Diego and Cape Flattery, where _`r survey.vessel`_ could not efficiently or safely navigate or trawl, two fishing vessels were used to conduct acoustic and purse-seine sampling (magenta lines, **Fig. \@ref(fig:survey-plan)**). _Long Beach Carnage_ planned to sample as close to shore as possible, typically to the 5-m isobath, along 5-nmi-long transects spaced 5 nmi apart between San Diego and Pacific Grove, CA, and 2.5-nmi-long transects spaced 2.5 nmi apart around Santa Cruz and Santa Catalina Islands in the SCB. _Lisa Marie_ planned to sample transects as close to shore as possible, typically to the 5-m isobath, spaced 7 nmi apart between Pacific Grove and Cape Flattery (**Fig. \@ref(fig:survey-plan)**). Off OR, _Lisa Marie_ planned to conduct coordinated comparative nighttime purse-seine sampling in the core region where _`r survey.vessel`_ observed backscatter from CPS during the day.  
+
+(ref:survey-plan) Planned compulsory transects sampled by NOAA Ship _`r survey.vessel`_ (black lines); adaptive transects to be sampled by the FSV when target CPS are present (dashed red lines); and nearshore transects sampled by _Lisa Marie_ and _Long Beach Carnage_ (magenta lines). White points indicate planned UCTD stations. Isobaths (light gray lines) are 50, 200, 500, and 2,000 m.
+
+```{r survey-plan,fig.cap='(ref:survey-plan)',out.height='8in',fig.pos='H'}
+include_graphics(here("Figs/fig_survey_map.png"))  
+```  
+
+\newpage  
+
+### Acoustic {#methods-acoustic-sampling}
+#### Acoustic equipment {#methods-acoustic-equipment}
+##### _`r survey.vessel`_  
+
+Multi-frequency Wide-Bandwidth Transceivers (`r echo.freqs.dash[survey.vessel.primary]`kHz Simrad EK80 WBTs; Kongsberg) were configured with split-beam transducers (Simrad `r echo.models[survey.vessel.primary]`, respectively; Kongsberg). The transducers were mounted on the bottom of a retractable keel or "centerboard" (**Fig. \@ref(fig:cb-config)**). The keel was retracted (transducers at ~`r cb.retracted`-m depth) during calibration, and extended to the intermediate position (transducers at ~`r cb.intermediate`-m depth) during the survey. Exceptions were made during shallow water operations, when the keel was retracted; or during times of heavy weather, when the keel was extended (transducers at ~`r cb.extended`-m depth) to provide extra stability and reduce the effect of weather-generated noise. In addition, acoustic data were also collected using a multibeam echosounder (Simrad ME70; Kongsberg), multibeam sonar (Simrad MS70; Kongsberg), scanning sonar (Simrad SX90; Kongsberg), acoustic Doppler current profiler and echosounder (Simrad EC150-3C, Kongsberg), and a separate ADCP (Ocean Surveyor OS75; Teledyne RD Instruments). Transducer position and motion were measured at 5 Hz using an inertial motion unit (Applanix POS-MV; Trimble).
+
+##### _Long Beach Carnage_
+
+On _Long Beach Carnage_, the SWFSC's multi-frequency Wideband Transceivers (`r echo.freqs.dash["LBC"]`kHz Simrad EK80 WBTs; Kongsberg) were configured with the SWFSC's split-beam transducers (Simrad `r echo.models["LBC"]`; Kongsberg) mounted in a multi-frequency transducer array (MTA4) on the bottom of a retractable pole (**Fig. \@ref(fig:cb-config-lbc)**). The transducers were at a water depth of approximately 2 m. 
+
+##### _Lisa Marie_  
+
+On _Lisa Marie_, multi-frequency Wideband Transceivers (`r echo.freqs.dash["LM"]`kHz Simrad EK80 WBTs; Kongsberg) were connected to the vessel's hull-mounted split-beam transducers (Simrad `r echo.models["LM"]`; Kongsberg). The transducers were mounted in a blister on the hull at a water depth of ~4 m (**Fig. \@ref(fig:cb-config-lm)**).  
+
+(ref:cb-config) Echosounder transducers mounted on the bottom of the retractable centerboard on _`r survey.vessel`_. During the survey, the centerboard was typically positioned in the intermediate position, placing the transducers ~2 m below the keel at a water depth of ~7 m.
+
+```{r cb-config,fig.cap='(ref:cb-config)',out.width='5in',fig.pos='H'}
+if (survey.vessel.primary == "RL") {
+  include_graphics(here("Images/img_centerboard_config_RL.png"))
+} else if (survey.vessel.primary == "SH") {
+  include_graphics(here("Images/img_centerboard_config_SH.png"))
+}
+```
+
+\newpage
+
+(ref:cb-config-lbc) Transducers (Top-bottom: Simrad ES200-7C, ES120-7C, ES38-12, and ES70-7C, Kongsberg) in a pole-mounted multi-transducer array (MTA4) installed on _Long Beach Carnage_.
+
+```{r cb-config-lbc,fig.cap='(ref:cb-config-lbc)',out.height = '4in',fig.align='center',fig.pos='H'}
+include_graphics(here("Images/img_carnage_mta4.jpg"))
+``` 
+
+(ref:cb-config-lm) Transducers (Simrad `r echo.models["LM"]`; Kongsberg, not visible) mounted in a blister on the hull of _Lisa Marie_. 
+
+```{r cb-config-lm,fig.cap='(ref:cb-config-lm)',out.height = '3.5in',fig.align='center',fig.pos='H'}
+include_graphics(here("Images/img_lisa-marie_transducer-blister.png"))
+``` 
+
+```{r process-cal}
+# Process calibration results from CW- and FM-mode calibrations. Vessel, procedure, and directory info is configured in the settings file for each survey.
+
+if (process.cal) {
+  # Plot CW calibration results
+  source(here("Code/processCal-CW.R"))
+  
+  # Plot FM calibration results
+  source(here("Code/processCal-FM.R"))
+  
+} else {
+  # Load CW results
+  load(here("Output/cal_results_CW.Rdata"))
+  
+  # Load FM results
+  load(here("Output/cal_results_FM.Rdata"))
+  
+}
+```
+
+\newpage
+
+#### Echosounder calibrations {#methods-echosounder-calibration}  
+##### _`r survey.vessel`_
+
+The echosounder systems aboard _`r survey.vessel`_ were calibrated on `r cal.datetime["RL"]` while the vessel was docked at `r cal.loc["RL"]` (`r cal.lat.dd["RL"]` $^{\circ}\textrm{N}$, `r cal.lon.dd["RL"]` $^{\circ}\textrm{W}$) using the standard sphere technique [@Foote1987; @Demer2015]. Each WBT was calibrated in both CW (i.e., continuous wave or narrowband mode) and FM mode (i.e., frequency modulation or broadband mode). For both CW and FM modes, the reference target was a `r cal.sphere["RL"]`; for FM mode, additional calibrations were conducted for the 120, 200, and 333-kHz echosounders using a 25-mm WC sphere (WC25). Prior to the calibrations, temperature and salinity were measured to a depth of 10 m using a handheld probe (Pro2030, YSI) to estimate sound speeds at the transducer and sphere depths, and the time-averaged sound speed and absorption coefficients for the range between them. The theoretical target strength ($TS$; dB re 1 m^2^) of the sphere was calculated using values for the sphere, sound-pulse, and seawater properties. The sphere was positioned throughout the main lobe of each of the transducer beams using three motorized downriggers, two on the port side of the vessel and one on the starboard side. The calibration parameters for all vessels were derived in Echoview. For each echosounder, the calibrated Equivalent Two-Way Beam Angle (EBA) was derived by compensating the factory-measured EBA by the change in local sound speed [@Demer2015;@Bodholt2002]; when processing the survey transects, the calibrated measures of transducer gain, beamwidths, and EBA were then also compensated by the changes in local sound speed. Calibration results for _`r survey.vessel`_ are presented in **Table \@ref(tab:cal-results)**, and were used to process the acoustic data used to estimate biomasses. Calibration plots for WBTs in CW and FM mode are presented in  **Appendix \@ref(appendix-calibration-plots-rl-cw)** and **Appendix \@ref(appendix-calibration-plots-rl-fm)**, respectively.  
+
+(ref:cal-results) Wide-Bandwidth Transceiver (Simrad EK80 WBT; Kongsberg) information, pre-calibration settings, and post-calibration beam model results (below the horizontal line) estimated from calibration of the echosounders aboard _`r survey.vessel`_ using a WC38.1 standard sphere.
+
+```{r cal-results, results='asis'}
+if (exists("all.output.RL")) {
+  # Copy calibration results
+  cal.results <- all.output.RL 
+  
+  # Get number of columns for table formatting
+  cal.cols <- ncol(cal.results)
+  
+  if (doc.type == "docx") {
+    # create kable object (for Word)
+    regulartable(cal.results)
+  } else {
+    # print LaTeX table for HTML or PDF
+    kable(cal.results, 
+          format = knitr.format, 
+          align = c("l","l",rep("c", cal.cols - 2)),
+          booktabs = TRUE, linesep = "", escape = FALSE,
+          caption = '(ref:cal-results)') %>% 
+      kable_styling(position = "center", latex_options = c("scale_down","hold_position")) %>%
+      add_header_above(c(" " = 2, "Frequency (kHz)" = cal.cols - 2)) %>% 
+      row_spec(7, hline_after = TRUE)
+  }
+} else {
+  print("No calibration results to present.")
+}
+```  
+
+\newpage
+
+##### _Long Beach Carnage_
+
+The WBTs aboard _Long Beach Carnage_ were calibrated on `r cal.datetime["LBC"]`, using the standard sphere technique [@Foote1987; @Demer2015], in a tank at the SWFSC [@Demer2015]. Calibration results for _Long Beach Carnage_ are presented in **Table \@ref(tab:cal-results-lbc)**, and were used to process the acoustic data used to estimate biomasses. Calibration plots for WBTs in CW mode are presented in **Appendix \@ref(appendix-calibration-plots-lbc)**.
+
+(ref:cal-results-lbc) Wideband Transceiver (Simrad EK80 WBT; Kongsberg) and transducer information (above horizontal line) and beam model results (below horizontal line) estimated from a tank calibration, using a WC38.1 standard sphere, of the echosounders later installed and used aboard _Long Beach Carnage_.
+
+```{r cal-results-lbc,results='asis'}
+if (exists("all.output.LBC")) {
+  # Copy calibration results
+  cal.results <- all.output.LBC
+  
+  # Get number of columns for table formatting
+  cal.cols <- ncol(cal.results)
+  
+  if (doc.type == "docx") {
+    # create kable object (for Word)
+    pander(cal.results)
+  } else {
+    kable(cal.results, 
+          format = knitr.format, 
+          align = c("l","l",rep("c", cal.cols - 2)),
+          booktabs = TRUE, linesep = "", escape = FALSE,
+          caption = '(ref:cal-results-lbc)') %>% 
+      kable_styling(position = "center", latex_options = c("scale_down","hold_position")) %>%
+      add_header_above(c(" " = 2, "Frequency (kHz)" = cal.cols - 2)) %>% 
+      row_spec(7, hline_after = TRUE)
+  }
+} else {
+  print("No calibration results to present.")
+}
+``` 
+
+\newpage
+
+##### _Lisa Marie_  
+
+The WBTs aboard _Lisa Marie_ were calibrated prior to the survey on `r cal.datetime["LM"]` using the standard sphere technique [@Foote1987; @Demer2015], while the vessel was anchored in `r cal.loc["LM"]` (`r cal.lat.dd["LM"]` $^{\circ}\textrm{N}$, `r cal.lon.dd["LM"]` $^{\circ}\textrm{W}$). Due to poor calibration results, a second calibration was conducted in Gig Harbor, WA (47.3344 $^{\circ}\textrm{N}$, -122.5817 $^{\circ}\textrm{W}$) on 16 September. Results from the post-survey _Lisa Marie_ calibration, presented in **Table \@ref(tab:cal-results-lm)**, were used to process the acoustic data used to estimate biomasses. Calibration plots for WBTs in CW mode are presented in **Appendix \@ref(appendix-calibration-plots-lm)**.  
+
+(ref:cal-results-lm) Wideband Transceiver (Simrad EK80 WBT; Kongsberg) and transducer information (above horizontal line) and beam model results (below horizontal line) estimated from a tank calibration, using a WC38.1 standard sphere, of the echosounders later installed and used aboard _Lisa Marie_.
+
+```{r cal-results-lm,results='asis'}
+# entered into the WBT control software (Simrad EK80; Kongsberg)
+
+if (exists("all.output.LM")) {
+  # Copy calibration results
+  cal.results <- all.output.LM 
+  
+  # Get number of columns for table formatting
+  cal.cols <- ncol(cal.results)
+  
+  if (doc.type == "docx") {
+    # create kable object (for Word)
+    pander(cal.results)
+  } else {
+    kable(cal.results, 
+          format = knitr.format, 
+          align = c("l","l",rep("c", cal.cols - 2)),
+          booktabs = TRUE, linesep = "", escape = FALSE,
+          caption = '(ref:cal-results-lm)') %>% 
+      kable_styling(position = "center", latex_options = c("scale_down","hold_position")) %>%
+      add_header_above(c(" " = 2, "Frequency (kHz)" = cal.cols - 2)) %>% 
+      row_spec(7, hline_after = TRUE)
+  }
+} else {
+  print("No calibration results to present.")
+}
+```  
+
+\newpage
+
+#### Data collection {#methods-acoustic-data-collection}  
+\
+
+On _`r survey.vessel`_, the computer clocks were synchronized with the GPS clock (UTC) using synchronization software (NetTime^[http://timesynctool.com]). The 18-kHz WBT, operated by a separate PC from the other EK80 WBTs, was programmed to track the seabed and output the detected depth to the ship’s Scientific Computing System (SCS). The echosounders were controlled by the EK80 Adaptive Logger [EAL^[https://www.fisheries.noaa.gov/west-coast/science-data/ek80-adaptive-logger/], @Renfree2016]. The EAL optimizes the pulse interval based on the seabed depth, while avoiding aliased seabed echoes, and can be programmed to periodically record pings in passive mode, for obtaining estimates of the background noise level. Acoustic sampling for CPS-density estimation along the pre-determined transects was limited to daylight hours (approximately between sunrise and sunset).  
+
+During daytime aboard _`r survey.vessel`_, measurements of volume backscattering strength ($S_v$; dB re 1 m^2^ m^-3^), indexed by time and geographic positions provided by GPS receivers, were logged to 60 m beyond the detected seabed range or to a maximum range of `r raw.log.range["RL"]` m for 38, 70, 120, 200, and 333 kHz, respectively, and stored, with a `r raw.size`-GB maximum file size, in Simrad-EK80 .raw format. At nighttime, echosounders were set to FM mode and logged to `r raw.log.range.night["RL"]` m to reduce data volume and to improve target strength ($TS$; dB re 1 m^2^) estimation and species differentiation for CPS in the depths sampled by the surface trawls. The prefix for the file names was a concatenation of the survey name (e.g.,  `r survey.name`), the operational mode (CW or FM), and the logging commencement date and time from the EK80 software. For example, a file generated by the EK80 software (`r ek80.version`) for a WBT operated in CW mode is named `2407RL-CW-D20240801-T125901.raw`.  
+
+To minimize acoustic interference, transmit pulses from all echosounders and sonars (i.e., EK80, ME70, MS70, SX90, EC150-3C, and ADCP) were triggered using a synchronization system (Simrad K-Sync; Kongsberg). The K-Sync trigger rate, and thus echosounder ping interval, was modulated by the EAL using the seabed depth measured using the 18-kHz echosounder. During both day and night, the ME70, SX90, and ADCP were operated and recorded continuously whenever possible. In 2024, the MS70 was inoperable, so no data were recorded. All other instruments that produce sound within the echosounder bandwidths were secured during daytime survey operations. Exceptions were made during stations (e.g., plankton sampling and fish trawling) or in shallow water when the vessel's command occasionally operated the bridge's 50- and 200-kHz echosounders (Furuno), the Doppler velocity log (SRD-500A; Sperry Marine), or both. Analyses of data from the ADCP, EC-150, ME70, MS70, and SX90 are not presented in this report.  
+
+On _Lisa Marie_ and _Long Beach Carnage_, the EAL was used to control the EK80 software to modulate the echosounder recording ranges (`r raw.log.range["LM"]` m for 38, 70, 120, and 200 kHz, respectively) and ping intervals to avoid aliased seabed echoes. When the EAL was not utilized, the EK80 was set to "auto-range" mode to adjust the maximum ping rate and recording range. Transmit pulses from the echosounders and fishing sonars were not synchronized. Therefore, the latter were secured during daytime acoustic transects.  
+
+### Oceanographic {#methods-oceanographic-sampling}
+#### Conductivity and temperature versus depth (CTD) {#methods-ctd-sampling}  
+\
+Conductivity and temperature were measured versus depth to `r ctd.cast.depth` m (or to within ~10 m of the seabed if shallower than `r ctd.cast.depth` m) with calibrated sensors on a CTD rosette (Model SBE911+, Seabird) or underway probe [RapidPro Plus (UCTD); Valeport] cast from the vessel. One to three casts were planned along each acoustic transect (**Fig. \@ref(fig:survey-plan)**). These data were used to calculate the harmonic mean sound speed [@Demer2015] for estimating ranges to the sound scatterers, and frequency-specific sound absorption coefficients for compensating signal attenuation of the sound pulse between the transducer and scatterers [@Simmonds2005] (see **Section \@ref(methods-sound-calcs)**).  
+
+\newpage
+
+#### Scientific Computer System {#methods-scs-sampling}  
+\
+While underway, information about the position and direction (e.g., latitude, longitude, speed, course over ground, and heading), weather (air temperature, humidity, wind speed and direction, and barometric pressure), and sea-surface oceanography (e.g., temperature, salinity, and fluorescence) were measured continuously and logged using the ship's Scientific Computer System (SCS). The data from a subset of these sensors, logged with a standardized format at 1-min resolution, are available on NOAA's ERDDAP data server^[`r paste0(erddap.url, erddap.vessel,".html")`].  
+
+<!-- ###  Fish-eggs {#methods-cufes-sampling}   -->
+
+<!-- On _`r survey.vessel`_, fish eggs were sampled during the day using a continuous underway fish egg sampler [CUFES, @Checkley1997], which collects water and plankton at a rate of ~640 l min^-1^ from an intake at ~3-m depth on the hull of the ship. The particles in the sampled water were sieved by a 505-$\mu$m mesh. Pacific Sardine, Northern Anchovy, Jack Mackerel, and Pacific Hake (_Merluccius productus_) eggs were identified to species, counted, and logged. Eggs from other species (e.g., Pacific Mackerel and flatfishes) were also counted and logged as "other fish eggs." Typically, the duration of each CUFES sample was 30 min, corresponding to a distance of 5 nmi at a speed of 10 kn. Because the durations of the early egg stages are short (i.e., less than 3 d) for most fish species, the egg distributions inferred from CUFES indicated the presence of actively spawning fish, and were used in combination with CPS echoes to select trawl locations.   -->
+
+### Species Composition and Demographics {#methods-trawl-sampling}  
+
+The net catches provide information about the regional species composition, lengths, weights and ages of CPS. After sunset, schools of CPS and other fish tend to ascend and disperse and are less likely to avoid a trawl net [@Mais1977]. Nighttime trawls conducted from _`r survey.vessel`_ sampled fish dispersed in the upper ~20-30 m of the sea surface. Beginning in the summer of 2023, and when weather conditions were favorable, the trawl net was towed along an arced path so that the net fished outside of the ship's wake [@Nottestad2015]. In 2024, a new Multifunction Trawl Net System (MFT; Swan Nets, Seattle, WA; **Figs. \@ref(fig:trawl-diagram-net)** and **\@ref(fig:trawl-diagram-codend)**), was used instead of the Nordic 264 [see net specifications in @Stierhoff2024] to trawl at night. Daytime purse-seine nets were set nearshore by _Long Beach Carnage_ and _Lisa Marie_ to sample CPS schools where their depth is constrained by the seabed and their vision is obscured by turbidity due to primary production and suspended particulates.  
+
+#### Trawl gear {#methods-trawl-gear}  
+
+Aboard _`r survey.vessel`_, the MFT was towed at the surface for 30 min at a speed of ~3.5 kn. The net has a rectangular opening with an area of approximately 648 m^2^ (~18-m tall x 36-m wide), a throat with variable-sized mesh, and a "marine mammal excluder device" to prevent the capture of large animals, such as dolphins, turtles, or sharks while retaining target species [@Dotson2010], and an 8-mm square-mesh cod-end liner (to retain a large range of animal sizes, **Figs. \@ref(fig:trawl-diagram-net)** and **\@ref(fig:trawl-diagram-codend)**). The trawl doors (Type 22 VK 4m2; Thyboron) have adjustable attachment points and flaps to modulate the depth of the doors, and the trawl headrope was configured with mesh pockets to allow for the addition of up to ten A4 floats to adjust the depth of the net. Temperature-depth recorders (TDRs; RBRduet^3^ T.D., RBR) were attached to the kite and footrope to measure the headrope depth and vertical net opening, and net mensuration sensors (Simrad PxPos sensors; Kongsberg) were installed on the doors to provide real-time measurements of door pitch, roll, depth, and spread for monitoring net performance (**Fig. \@ref(fig:tv80-example)**).  
+
+#### Purse-seine gear {#methods-seine-sampling}  
+
+_Lisa Marie_ used an approximately 440-m-long and 40-m-deep purse-seine net with 17-mm-wide mesh (A. Blair, pers. comm.). _Long Beach Carnage_ used an approximately 200-m-long and 27-m-deep purse-seine net with 17-mm-wide mesh; a small section on the back end of the net had 25-mm-wide mesh (R. Ashley, pers. comm.). Specimens collected by _Lisa Marie_ were processed aboard the vessel by the WA Department of Fish and Wildlife (WDFW; see **Section \@ref(methods-seine-processing-lm)**), and specimens collected aboard _Long Beach Carnage_ were processed ashore by the CA Department of Fish and Wildlife (CDFW; see **Section \@ref(methods-seine-processing-lbc)**)).  
+
+\newpage
+\blandscape
+
+(ref:trawl-diagram-net) Schematics of the Multifunction Trawl Net System panels as viewed from the a) top, b) bottom, and c) side.
+
+```{r trawl-diagram-net, fig.cap='(ref:trawl-diagram-net)',out.height='5in',fig.pos='H'}
+include_graphics(here("Images/img_MFT_trawl.png")) 
+``` 
+
+\elandscape
+\newpage 
+
+(ref:trawl-diagram-codend) Schematics of the Multifunction Trawl Net System a) rigging and b) cod-end.
+
+```{r trawl-diagram-codend, fig.cap='(ref:trawl-diagram-codend)',out.height='6in',fig.pos='H'}
+include_graphics(here("Images/img_MFT_rigging_codend.png")) 
+``` 
+
+\newpage 
+\blandscape
+
+(ref:tv80-example) Example plot illustrating net performance during the net deployment (dashed box) and when actively fishing (shaded region) by combining outputs from the SCS, temperature-depth recorders (TDR), and Simrad PxPos sensors. (Top) The vessel speed over ground (kn, black line), measured using the ship’s GPS, and depths of the trawl kite (purple line) and footrope (blue line), measured using TDRs, and the port (green line) and starboard doors (red line), measured using the PxPos sensors. (Middle) Height of the net opening measured as the difference between the kite and footrope depths. (Bottom) The spread of the doors measured by the PxPos sensors.
+
+```{r tv80-example, fig.cap='(ref:tv80-example)',out.height='5in',fig.align='center',fig.pos='H'}
+include_graphics(here("Images/img_TV80_example.png")) 
+```
+
+\elandscape
+\newpage
+
+#### Sampling locations {#methods-trawl-locations}  
+##### _`r survey.vessel`_ {#methods-trawl-locations-lasker}  
+
+Up to three nighttime (i.e., 30 min after sunset to 30 min before sunrise) surface trawls, typically spaced at least 10-nmi apart, were conducted in locations where putative CPS schools were observed by an acoustician in echograms earlier that day. If no CPS echoes were observed along a transect that day, the trawls were alternately placed nearshore that night and offshore the next night, with consideration given to the seabed depth and the modeled distribution of CPS habitat. The locations were provided to the watch officers who charted the proposed trawl sites. Each morning, after the last trawl or no earlier than 30 min prior to sunrise, _`r survey.vessel`_ resumed sampling at the location where the acoustic sampling stopped the previous day.  
+
+##### _Lisa Marie_ and _Long Beach Carnage_ {#methods-seine-locations}  
+
+On _Lisa Marie_ and _Long Beach Carnage_, as many as three purse-seine sets were conducted each day where CPS schools were observed at the surface or in echograms. For each set, three dip-net samples were collected that were spatially separated as much as possible.  
+
+#### Sample processing {#methods-sample-processing}  
+##### _`r survey.vessel`_  {#methods-trawl-processing}
+
+If the total volume of the trawl catch was less than or equal to five 35-l baskets (~175 l), all target species were separated from the catch, sorted by species, weighed, and enumerated. If the volume of the entire catch was more than five baskets, a random five-basket subsample that included non-target species was collected, sorted by species, weighed, and enumerated; the remainder of the total catch was weighed. In these cases, the weight of the entire catch was calculated as the sum of the subsample and remainder weights. The weight of the $e$-th species in the total catch ($C_{T,e}$) was obtained by summing the catch weight of the respective species in the subsample ($C_{S,e}$) and the corresponding catch in the remainder ($C_{R,e}$), which was calculated as:  
+
+\begin{equation}
+C_{R,e} = C_R*P_{w,e}\text{,}
+(\#eq:remainder-catch-weight)
+\end{equation}
+
+where $P_{w,e} = C_{S,e}/C_{S}$, is the proportion in weight of the $e$-th species in the subsample. The number of specimens of the $e$-th species in the total catch ($N_{T,e}$) was estimated by:  
+
+\begin{equation}
+N_{T,e} = \frac{C_{T,e}}{\overline{w}_e}\text{,}
+(\#eq:number-specimens-catch)
+\end{equation}
+
+where $\overline{w}_e$ is the mean weight of the $e$-th species in the subsample. For Pacific Sardine and Northern Anchovy, individual measurements of standard length ($L_S$, mm) and weight ($w$, g) were recorded for up to 75 specimens. For Jack Mackerel, Pacific Mackerel, Pacific Herring, and Round Herring, individual measurements of fork length ($L_F$) and $w$ were recorded for up to 50 specimens. In addition, sex and maturity were recorded for all Pacific Sardine processed for lengths. Ovaries were only preserved for Pacific Sardine that were considered active and spawning. Fin clips were removed from all Pacific Sardine processed for lengths and up to 50 Northern Anchovy per trawl from seven geographic zones (with boundaries at the Columbia River, Cape Mendocino, San Francisco Bay, Point Conception, San Diego, and San Quentin, Baja CA) and preserved in ethanol for genetic analysis. Otoliths were removed from all Pacific Sardine in the subsample; for Northern Anchovy, Pacific Mackerel, and Jack Mackerel, up to 25 otoliths were removed from the available specimens as equally as possible from the range of sizes present. The combined catches in up to three trawls per night (i.e., trawl cluster) were used to estimate the proportions of species contributing to the nearest samples of acoustic backscatter. Japanese Sardine (_Sardinops melanosticta_) were present in the survey area during the survey period [@Longo2025]. However, due to their anatomical resemblance, all sardine were processed as if they were Pacific Sardine (_S. sagax_).  
+
+##### _Lisa Marie_ {#methods-seine-processing-lm}  
+
+For each dip-net sample, all specimens were sorted, weighed, and counted to provide a combined weight and count for each species. Next, all three dip-net samples were combined and up to 50 specimens of each CPS species were randomly sampled to provide individual measures of weight and length ($L_S$ for Pacific Sardine and Northern Anchovy and $L_F$ for all others) and weight for each set. Otoliths were extracted and macroscopic maturity stage was determined visually for CPS. For Pacific Sardine, tissue samples were collected and stored in ethanol for later genetic analysis.  
+
+##### _Long Beach Carnage_ {#methods-seine-processing-lbc}  
+
+For each dip-net sample, all specimens were sorted, weighed, and counted to provide a combined weight and count for each species. Then all dip net samples were combined and as many as 50 specimens of each CPS species present were chosen randomly throughout the sample and frozen for later analysis by CDFW biologists, yielding individual measures of weight, length ($L_S$ for Pacific Sardine and Northern Anchovy and $L_F$ for all others), and maturity. No female gonad samples were analyzed. Otoliths were collected but not aged.  For some specimens, fin clips were collected in the laboratory from specimens that were frozen at sea, and those samples were stored in ethanol for later genetic analysis.    
+
+#### Quality Assurance and Quality Control {#methods-trawl-qaqc}  
+
+At sea, trawl data were entered into a database (Microsoft Access). During and following the survey, data were further scrutinized and verified, or corrected. Missing length ($L_{miss}$) and weight ($W_{miss}$) measurements were estimated as $W_{miss} = \beta_0{L}^{\beta_1}$ and $L_{miss} = (W/\beta_0)^{(1/\beta_1)}$, respectively, where values for $\beta_0$ and $\beta_1$ are species- and season-specific parameters of the length-versus-weight relationships described in Palance et al. [-@Palance2019]. To identify measurement or data-entry errors, length and weight data were graphically compared (**Fig.** \@ref(fig:lw-plot)) to measurements from previous surveys and models of season-specific length-versus-weight from previous surveys [@Palance2019]. Outliers were flagged, reviewed, and corrected if errors were identified. Catch data were removed from aborted trawl hauls.  
+
+#### Comparative nighttime trawl and purse seine sampling {#methods-trawl-seine-comparison}  
+
+From 31 August to 6 September, off the coast of central OR, _Lisa Marie_ conducted nighttime purse seine sampling in core region areas where _`r survey.vessel`_ conducted nighttime trawling on the same evening (**Fig.** \@ref(fig:trawl-seine-comp-map)). This one-time research effort was not part of operational survey, and data collected during this effort were not used to estimate biomass. Prior to sunset, acousticians aboard _`r survey.vessel`_ provided the crew of _Lisa Marie_ up to three planned trawl locations for that evening. Upon completion of each trawl, _Lisa Marie_ attempted to set their purse seine as close as possible in space and time to the trawl location. Catches from both vessels were processed in the same manner as those from the main portion of the survey. Species proportions and size distributions were compared to examine similarities and differences between the two net sampling methods used to apportion acoustic backscatter observed in the core survey area.  
+
+\newpage
+\blandscape
+
+(ref:lw-plot) Specimen weight versus length from the current survey (colored points, by sex) compared to those from previous SWFSC surveys during the same season (gray points) and length-weight models from Palance et al. [-@Palance2019], except for Round Herring, which was fit using data from recent surveys (dashed lines). 
+
+```{r lw-plot, fig.cap='(ref:lw-plot)',out.width='8in',fig.pos='H'}
+include_graphics(here("Figs/fig_LW_plots.png"))
+```  
+
+\elandscape
+\newpage
+
+```{r trawl-seine-comp-figures, include=FALSE}
+# Generate catch comparison figures
+if (save.figs) source(here("Code/comp_seine_2407RL.R"))
+```
+
+(ref:trawl-seine-comp-map) Locations of nighttime trawls (black lines) and purse seine sets (red points) used to compare net sampling methods. The dashed line indicates the path of _`r survey.vessel`_ during daytime acoustic sampling and nighttime trawling.
+
+```{r trawl-seine-comp-map, fig.cap='(ref:trawl-seine-comp-map)',out.height='8in',fig.pos='H'}
+# Include map showing locations of trawl hauls and seine sets
+include_graphics(here("Figs/fig_trawl_seine_sets_comp.png"))
+```  
+
+\newpage
+
+## Acoustic data processing {#methods-data-processing}  
+### Acoustic and oceanographic data {#methods-acoustic-processing}  
+
+The calibrated echosounder data from each transect were processed using commercial software ([Echoview](https://www.echoview.com/) `r ev.version`; Echoview Software Pty Ltd.) and estimates of the sound speed and absorption coefficient calculated with contemporaneous data from CTD probes cast while stationary or underway (UCTD, see **Section \@ref(methods-ctd-sampling)**). Data collected along the daytime transects at speeds $\geq$ 5 kn were used to estimate CPS densities. Nighttime acoustic data were not used for biomass estimations because they are assumed to be negatively biased due to diel-vertical migration and disaggregation of the target species’ schools [@Cutter2008].  
+
+### Sound speed and absorption compensation {#methods-sound-calcs}  
+
+CTD casts provide measures of pressure, conductivity, and temperature, from which depth, salinity, and sound speed ($c_{w}$, m s^-1^) are derived. On _Lasker_, the underway CTD probe (RapidPro Plus; Valeport) provided pre-processed data containing temperature and derived measures of depth, salinity, and $c_{w}$. On _Lisa Marie_, the CTD probe (SBE19plus; Seabird) provided raw measures of pressure, conductivity, and temperature, for which post-processing software (Seabird SBEDataProcessing) was used to filter the data, derive depth, average into 1-m bins, then derive salinity and $c_{w}$ for each bin. For both probes, values of depth and $c_{w}$ for the downcast were defined in transect-specific Echoview Calibration Supplement (ECS) files utilized for the Echoview data processing. The $c_{w}$ profile is used to estimate ranges to the sound scatterers and to compensate the echo signal for spherical spreading and attenuation during propagation of the sound pulse from the transducer to the scatterer range and back [@Simmonds2005]. Similarly, the average temperature, salinity, and depth, along with the harmonic mean of $c_{w}$, were computed over the entire downcast and defined in the ECS file. These averaged values are used by Echoview to calculate absorption coefficients which account for frequency-dependent absorption losses. Lastly, the calibration parameters were updated to compensate for changes in local $c_{w}$ relative to that at the time of the calibration [@Bodholt2002]:
+
+\begin{equation}
+G_0=G_0^{'}+20log_{10}\left(\frac{c_w^{'}}{c_w}\right)\text{,}
+(\#eq:compensate-gain-sound-speed)
+\end{equation}
+
+\begin{equation}
+\Psi=\Psi^{'}+20log_{10}\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-EBA-sound-speed)
+\end{equation}
+
+\begin{equation}
+\alpha_\mathrm{-3dB}=\alpha_\mathrm{-3dB}^{'}*\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-AlongBW-sound-speed)
+\end{equation}
+
+\begin{equation}
+\beta_\mathrm{-3dB}=\beta_\mathrm{-3dB}^{'}*\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-AthwtBW-sound-speed)
+\end{equation}
+
+where the prime symbol denotes values from the calibration and $c_{w}$ is at the depth of the transducer. The CTD rosette, when cast, also provides measures of fluorescence and dissolved oxygen concentration versus depth, which may be used to estimate the vertical dimension of Pacific Sardine potential habitat [@Zwolinski2011], particularly the depth of the upper-mixed layer where most epipelagic CPS reside. The latter information is used to inform echo classification (see **Section \@ref(methods-echo-classification)**).
+
+The CTD probe used by _Long Beach Carnage_ malfunctioned at the beginning of their survey. Therefore, the oceanographic data used for generating the ECS files to process the _Long Beach Carnage_ acoustic data was obtained from the nearest _Lasker_ underway CTD cast.
+
+### Echo classification {#methods-echo-classification}  
+
+Echoes from schooling CPS (**Figs. \@ref(fig:ev-filtering-example)a, d**) were identified using the semi-automated data processing algorithm described below and implemented using Echoview software (`r ev.version`; Echoview Software Pty Ltd). The filters and thresholds were based on a subsample of echoes from randomly selected CPS schools. The aim of the filter criteria is to retain at least 95% of the noise-free backscatter from CPS while rejecting at least 95% of the non-CPS backscatter (**Fig. \@ref(fig:ev-filtering-example)**). Data from _`r survey.vessel`_, _Lisa Marie_, and _Long Beach Carnage_ were processed using the following steps:  
+
+1. Match geometry of all $S_v$ variables to the 38-kHz $S_v$;
+2. Remove passive-mode pings;
+3. Estimate and subtract background noise using the background noise removal function [@DeRobertis2007] in Echoview (**Figs. \@ref(fig:ev-filtering-example)b, e**);
+4. Average the noise-free $S_v$ echograms using non-overlapping 11-sample by 3-ping bins;
+5. Expand the averaged, noise-reduced _S~v~_ echograms with a 7 pixel x 7 pixel dilation;
+6. For each pixel, compute: $S_{v,\mathrm{200kHz}}-S_{v,\mathrm{38kHz}}$, $S_{v,\mathrm{120kHz}}-S_{v,\mathrm{38kHz}}$, and $S_{v,\mathrm{70kHz}}-S_{v,\mathrm{38kHz}}$;
+7. Create a Boolean echogram for $S_v$ differences in the CPS range: $-13.85 < S_{v,\mathrm{70kHz}}-S_{v,\mathrm{38kHz}} < 9.89 \text{ and} -13.5 < S_{v,\mathrm{120kHz}}-S_{v,\mathrm{38kHz}} < 9.37 \text{ and} -13.51 < S_{v,\mathrm{200kHz}}-S_{v,\mathrm{38kHz}} < 12.53$;
+8. For 120 and 200 kHz, compute the squared difference between the noise-filtered $S_v$ (Step 3) and averaged $S_v$ (Step 4), average the results using an 11-sample by 3-ping window to derive variance, then compute the square root to derive the 120- and 200-kHz standard deviations ($\sigma_{\mathrm{120kHz}}$ and $\sigma_{\mathrm{200kHz}}$, respectively);
+9. Expand the standard deviation echograms with a 7 pixel x 7 pixel dilation;
+10. Create a Boolean echogram based on the standard deviations in the CPS range: $\sigma_{\mathrm{120kHz}}$ > -65 dB and $\sigma_{\mathrm{200kHz}}$ > -65 dB. Diffuse backscattering layers have low $\sigma$ [@Zwolinski2010] whereas fish schools have high $\sigma$;
+11. Intersect the two Boolean echograms to create an echogram with "TRUE" samples for candidate CPS schools and "FALSE" elsewhere;
+12. Mask the noise-reduced echograms using the CPS Boolean echogram (**Figs. \@ref(fig:ev-filtering-example)c, f**);
+13. Create an integration-start line `r int.start` m below the transducer (~10 m depth);
+14. Create an integration-stop line `r adz.range` m above the estimated seabed [@Demer2009a], or to the maximum logging range (e.g., `r int.stop` m), whichever is shallowest;
+15. Set the minimum $S_v$ threshold to -70 dB (corresponding to a density of approximately three 20-cm-long Pacific Sardine per 100 m^3^);
+16. Integrate the volume backscattering coefficients ($s_V$, m^2^ m^-3^) attributed to CPS over 5-m depths and averaged over 100-m distances;
+17. Output the resulting nautical area scattering coefficients ($s_A$; m^2^ nmi^-2^) and associated information from each transect and frequency to comma-delimited text (.csv) files.  
+
+When necessary, the start and stop integration lines were manually edited to exclude reverberation due to bubbles, include the entirety of shallow CPS aggregations, and exclude seabed echoes.  
+
+### Removal of non-CPS backscatter {#methods-backscatter-removal}  
+
+In addition to echoes from target CPS, echoes may also be present from other pelagic fish species (Pacific Saury, _Cololabis saira_), or semi-demersal fish such as Pacific Hake and rockfishes ($Sebastes$ spp.). When analyzing the acoustic-survey data, it was therefore necessary to filter "acoustic by-catch," i.e., backscatter not from the target species. To exclude these echoes, echograms were visually examined using R and integration depths were edited to exclude echoes where the seabed was hard and rugose, or where diffuse schools were observed either near the surface or deeper than ~250 m (**Fig. \@ref(fig:extract-nasc)**). In areas dominated by Pacific Herring, for example off Vancouver Island, backscatter was integrated to a maximum depth of 75 m.  
+
+(ref:ev-filtering-example) Two examples of echograms depicting CPS schools (red) and plankton aggregations (blue and green) at 38 kHz (top) and 120 kHz (bottom). Example data processing steps include the original echogram (a, d), after noise subtraction and bin-averaging (b, e), and after filtering to retain only putative CPS echoes (c, f).
+
+```{r ev-filtering-example,fig.cap='(ref:ev-filtering-example)',out.width='6.5in',fig.pos='H'}
+include_graphics(here("Images/img_echoview_filtering_example-labeled.png"))
+```  
+
+(ref:extract-nasc) Echoes from fishes with swimbladders (blue points, scaled by backscatter intensity) along an example acoustic transect (top) and the corresponding echogram image (bottom). In this example, the upper (blue) and lower lines (green) indicate boundaries within which echoes were retained. Where the lower boundary was deeper than the seabed (black line), echoes above the seabed were retained. Echoes from deep, bottom-dwelling schools of non-CPS fishes with swimbladders, and from diffuse scatterers near the surface were excluded.
+
+```{r extract-nasc,fig.cap='(ref:extract-nasc)',out.width='6.5in',fig.pos='H'}
+include_graphics(here("Images/img_extract_nasc_example.png"))
+```  
+
+### Quality Assurance and Quality Control {#methods-acoustics-qaqc}  
+
+The largest 38-kHz vertically integrated backscattering coefficients ($s_A$, m^2^ nmi^-2^) were graphically examined to identify potential errors in the integrated data (e.g.,  when a portion of the seabed was accidentally integrated). If found, errors were corrected and data were re-integrated prior to use for biomass estimation.  
+
+### Echo integral partitioning and acoustic inversion {#methods-echointegration}  
+
+For fishes with swimbladders, the acoustic backscattering cross-section of an individual ($\sigma_{bs}$, m^2^) depends on many factors but mostly on the acoustic wavelength and the swimbladder size and orientation relative to the incident sound pulse. For echosounder sampling conducted in this survey, $\sigma_{bs}$ is primarily a function of the dorsal-surface area of the swimbladder and was approximated by a function of fish length ($L$), i.e.:
+
+\begin{equation}
+\sigma_{bs} = 10^{\frac{m\,\log_{10}(L)+b}{10}}\text{,}
+(\#eq:sigma-bs)
+\end{equation}
+
+where $m$ and $b$ are frequency and species-specific parameters that are obtained theoretically or experimentally (see references below). $TS$, a logarithmic representation of $\sigma_{bs}$, is defined as:
+
+\begin{equation}
+TS = 10\,\log_{10}(\sigma_{bs}) = m\,\log_{10}(L) + b\text{.}
+(\#eq:ts-sigma-bs-equation)
+\end{equation}
+
+$TS$ has units of dB re 1 m^2^ if defined for an individual, or dB re 1 m^2^ kg^-1^ if defined by weight. The following equations for $TS_{38\mathrm{kHz}}$ were used in this analysis:  
+
+\begin{equation}
+TS_{\mathrm{38kHz}} = -14.90 \times \log_{10} (L_T) - 13.21 \text{, for Pacific Sardine;}
+(\#eq:tl-ts-sardine)
+\end{equation}
+
+\begin{equation}
+TS_{\mathrm{38kHz}} = -11.97 \times \log_{10} (L_T) - 11.58561 \text{, for Pacific and Round Herrings;}
+(\#eq:tl-ts-herring)
+\end{equation}
+
+\begin{equation}
+TS_{\mathrm{38kHz}} = -13.87 \times \log_{10} (L_T) - 11.797 \text{, for Northern Anchovy; and}
+(\#eq:tl-ts-anchovy)
+\end{equation}
+
+\begin{equation}
+TS_{\mathrm{38kHz}} = -15.44 \times \log_{10} (L_T) - 7.75 \text{, for Pacific and Jack Mackerels,}
+(\#eq:tl-ts-mackerel)
+\end{equation}
+
+where the units for total length ($L_T$) is cm and $TS$ is dB re 1 m^2^ kg^-1^.  
+
+Equations \@ref(eq:tl-ts-sardine) and \@ref(eq:tl-ts-mackerel) were derived from echosounder measurements of $\sigma_{bs}$ for in situ fish and measures of $L_T$ and $W$ from concomitant catches of South American Pilchard (_Sardinops ocellatus_) and Horse Mackerel (_Trachurus trachurus_) off South Africa [@Barange1996]. Because mackerels have similar $TS$ [@Pena2008], Equation \@ref(eq:tl-ts-mackerel) is used for both Pacific and Jack Mackerels. For Pacific Herring and Round Herring, Equation \@ref(eq:tl-ts-herring) was derived from that of Thomas et al. [-@Thomas2002] measured at 120 kHz with the following modifications: 1) the intercept used here was calculated as the average intercept of Thomas et al.'s spring and fall regressions; 2) the intercept was compensated for swimbladder compression after Zhao et al. [-@Zhao2008] using the average depth for Pacific Herring of 44 m; and 3) the intercept was increased by 2.98 dB to account for the change of frequency from 120 to 38 kHz [@Saunders2012]. For Northern Anchovy, Equation \@ref(eq:tl-ts-anchovy) was derived from that of Kang et al. [-@Kang2009], after compensation of the swimbladder volume [@Ona2003;@Zhao2008] for the average depth of Northern Anchovy observed in summer 2016 [19 m, @Zwolinski2017].  
+
+To calculate $TS_{38\mathrm{kHz}}$, $L_T$ was estimated from measurements of $L_S$ or $L_F$ using linear relationships between length and weight derived from specimens collected in the CCE [@Palance2019]: for Pacific Sardine, $L_T = 0.3574 + 1.149L_S$; for Northern Anchovy, $L_T = 0.2056 + 1.1646 L_S$; for Pacific Mackerel, $L_T = 0.2994 + 1.092 L_F$; for Jack Mackerel $L_T = 0.7295 + 1.078 L_F$; and for Pacific Herring $L_T = -0.105 + 1.2 L_F$. Since a conversion does not exist for Round Herring, the equation for Pacific Herring was used to estimate $L_T$, when present.  
+
+The proportions of species in a trawl cluster were considered representative of the proportions of species in the vicinity of the cluster. Therefore, the proportion of the echo-integral from the $e$-th species ($P_e$) in an ensemble of $s$ species can be calculated from the species catches $N_1, N_2,..., N_s$ and the respective average backscattering cross-sections $\sigma_{bs_1}, \sigma_{bs_2},...,\sigma_{bs_s}$ [@Nakken1975]. The proportion of acoustic backscatter for the $e$-th species in the $a$-th trawl ($P_{ae}$) is:
+
+\begin{equation}
+P_{ae} = \frac{N_{ae} \times \overline{w}_{ae} \times \overline{\sigma}_{bs,ae}}{\sum_{e=1}^{s_a} (N_{ae} \times \overline{w}_{ae} \times \overline{\sigma}_{bs,ae})}\text{, }
+(\#eq:acoustic-prop-spp)
+\end{equation}
+
+where $\overline{\sigma}_{bs,ae}$ is the arithmetic counterpart of the average target strength ($\overline{TS}_{ae}$) for all $n_{ae}$ individuals of species $e$ in the random sample of trawl $a$:  
+
+\begin{equation}
+\overline{\sigma}_{bs,ae} = \frac{\sum_{i=1}^{n_{ae}}10^{(TS_i/10)}}{n_{ae}}\text{, }
+(\#eq:avg-ts-all-spp)
+\end{equation}
+
+and $\overline{w}_{ae}$ is the average weight: $\overline{w}_{ae} = \sum_{i=1}^{n_{ae}}{w_{aei}}/{n_{ae}}$. The total number of individuals of species $e$ in a trawl $a$ ($N_{ae}$) is obtained by: $N_{ae}=\frac{n_{ae}}{w_{s,ae}} \times w_{t,ae}$, where $w_{s,ae}$ is the weight of the $n_{ae}$ individuals sampled randomly, and $w_{t,ae}$ is the total weight of the respective species' catch.  
+
+The trawls within a cluster were combined to reduce sampling variability (see **Section \@ref(methods-trawl-clustering)**), and the number of individuals caught from the $e$-th species in a cluster $g$ ($N_{ge}$) was obtained by summing the catches across the $h$ trawls in the cluster: $N_{ge}=\sum_{a=1}^{h_g}N_{ae}$. The backscattering cross-section for species $e$ in the $g$-th cluster with $a$ trawls is then given by:  
+
+\begin{equation}
+\overline{\sigma}_{bs,ge}=\frac{\sum_{a=1}^{h_g} N_{ae} \times \overline{w}_{ae} \times \overline{\sigma}_{bs,ae}}{\sum_{a=1}^{s_g} N_{ae} \times \overline{w}_{ae}}\text{, }
+(\#eq:sigma-spp-j)
+\end{equation}
+
+where:  
+
+\begin{equation}
+\overline{w}_{ge} = \frac{\sum_{a=1}^{h_g} N_{ae} \times \overline{w}_{ae}}{\sum_{a=1}^{h_g} N_{ae}}\text{, }
+(\#eq:w-spp-j)
+\end{equation}
+
+and the proportion ($P_{ge}$) is;
+
+\begin{equation}
+P_{ge} = \frac{N_{ge} \times \overline{w}_{ge} \times \overline{\sigma}_{bs,ae}}{\sum_{e=1}^{s}(N_{ge} \times \overline{w}_{ge} \times \overline{\sigma}_{bs,ge})}\text{.}
+(\#eq:prop-spp-j)
+\end{equation}  
+
+### Trawl clustering and species proportion {#methods-trawl-clustering}  
+
+Nighttime trawl and daytime purse seine samples were used to apportion backscatter in the core and nearshore areas, respectively. Trawls that occurred on the same night were assigned to a trawl cluster. Biomass densities ($\rho$; t nmi^-2^) were calculated for 100-m transect intervals by dividing the integrated area-backscatter coefficients for each CPS species by the mean backscattering cross-sectional area [@MacLennan2002] estimated in the trawl cluster or purse seine nearest in space. Acoustic transects were post-stratified to account for spatial heterogeneity in sampling effort and biomass density in a similar way to that performed for Pacific Sardine [@Zwolinski2016; @PFMC2018].  
+
+For a generic 100-m long acoustic interval, the vertically summed area-backscattering coefficient for species $e$ was computed as: $s_{A,e} = s_{A,cps} \times P_{ge}$, where $s_{A,cps}$ is the vertically summed area-backscattering coefficient for all CPS and $P_{ge}$ (Equation \@ref(eq:prop-spp-j)) is the proportion of acoustic backscatter from species $e$ in the nearest trawl cluster or purse seine (**Fig. \@ref(fig:trawl-cluster-map-combo)**). Then, $s_{A,e}$ was used to estimate the biomass density ($\rho_{w,e}$) [@MacLennan2002; @Simmonds2005] for every 100-m interval:
+
+\begin{equation}
+\rho_{w,e} = \frac{s_{A,e}}{4\pi\overline{\sigma}_{bs,e}}\text{.}
+(\#eq:biomass-density)
+\end{equation}
+
+In 2024, purse seine sampling was sparse in some areas where CPS backscatter was observed, so the nearest purse seine or trawl cluster were used to apportion backscatter, whichever was closest in space (**Fig. \@ref(fig:trawl-cluster-map-combo), b**).  
+
+The biomass densities were converted to numerical densities using: $\rho_{n,e}=\rho_{w,e}/\overline{w}_e$, where $\overline{w}_e$ is the corresponding mean weight. Also, for each acoustic interval, the biomass or numeric densities are partitioned into length classes according to the species' length distribution in the respective trawl cluster or purse seine.  
+
+\newpage
+
+(ref:trawl-cluster-map-combo) Polygons enclosing 100 m-long acoustic transect intervals sampled by a) _`r survey.vessel`_ in the core region and b) _Long Beach Carnage_ and _Lisa Marie_ in the nearshore region relative to the nearest trawl cluster or purse-seine set used to apportion acoustic backscatter. The colored numbers inside each polygon indicate the sample number and gear type. Dark gray numbers indicate trawl clusters or purse-seine sets with no CPS present in the catch.
+
+```{r trawl-cluster-map-combo,fig.cap='(ref:trawl-cluster-map-combo)',out.width='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_nasc_cluster_map_combo.png"))
+```  
+
+\newpage
+
+(ref:trawl-cluster-map-ns) a) Polygons enclosing 100-m acoustic intervals from _Long Beach Carnage_ and _Lisa Marie_ assigned to catches from each purse seine or trawl cluster, and b) the proportion of acoustic backscatter ascribed to each CPS species present in the catch from each purse seine (white outline) or trawl cluster (black outline). The numbers inside each polygon in panel a) are the purse seine (red) or trawl cluster numbers (blue), which are located at the location of the purse seine set or a the average latitude and longitude of all trawls in the cluster.
+
+```{r trawl-cluster-map-ns,fig.cap='(ref:trawl-cluster-map-ns)',out.width='6.5in',fig.pos='H',eval=FALSE}
+include_graphics(here("Figs/fig_nasc_seine_cluster_wt_ns.png"))
+```  
+
+\newpage  
+
+## Data analysis {#methods-data-analysis}
+### Post-stratification {#methods-post-stratification}  
+
+The transects were the sampling units [@Simmonds1996]. Because most species do not generally span the entire survey area [@Zwolinski2014; @Demer2017], the sampling domain was post-stratified for each species and subpopulation [@Zwolinski2016; @PFMC2018]. Strata were defined by uniform transect spacing (i.e., sampling intensity) and either the presence (i.e., positive densities and potentially structural zeros) or absence (i.e., real zeros) of biomass for each species. Each stratum has: 1) at least three transects, with approximately equal spacing, 2) fewer than three consecutive transects with zero-biomass density, and 3) bounding transects with zero-biomass density (**Fig. \@ref(fig:tx-biom-dens)**). This approach tracks patchiness and creates statistically-independent, stationary, post-sampling strata [@Johannesson1983; @Simmonds1992]. For Northern Anchovy, we define the separation between the northern and central subpopulations at `r names(stock.break.anch)` (`r round(stock.break.anch,1)` $^{\circ}\textrm{N}$). For Pacific Sardine, the northern subpopulation biomass present in the survey area [@Hill2014; @Felix-Uraga2004; @Felix-Uraga2005; @Garcia-Morales2012] was separated using the revised model of Pacific Sardine potential habitat [@Zwolinski2024] during the survey (**Fig. \@ref(fig:transects-and-habitat-all)**), with all other Pacific Sardine biomass considered to belong to the southern subpopulation. This separation is further supported by different distributions of $L_S$ and a break in the distribution of Pacific Sardine biomass, which, in this survey, coincided geographically with `r names(stock.break.sar)` (`r round(stock.break.sar, 1)` $^{\circ}\textrm{N}$, **Fig. \@ref(fig:tx-biom-dens)**).  
+
+### Analysis of deep backscatter in the nearshore region  
+
+<!-- **[Significant deep backscatter that was likely anchovy was observed by the LM near Pacific Grove. The nearest purse seine set was in northern Monterey Bay and contained entirely sardine. The decision was made to use the nearest purse seine OR trawl cluster to apportion nearshore backscatter. The biomass resulting from the backscatter of the deep schools in this region. We must still estimate biomass from deep backscatter, but the subsequent analyses will result in an increase in CSNA biomass but should not impact the biomasses of P. sardine nearby, so we will conduct this analysis in parallel with ongoing reviews.]**  -->
+
+In some areas, dense backscatter was observed deeper than the upper mixed layer (approximately 30-m deep) in the nearshore region. In those areas, the purse-seine catches sampled using a 27-m deep net contained mostly Pacific Sardine, which typically reside above the thermocline (J. Zwolinski, unpublished data), which was likely not representative of the species present in those areas. Therefore, the CPS backscatter shallower than 30 m was apportioned using the length and species composition of all CPS in the nearest purse seine sample or trawl cluster and used to estimate biomass density. Biomass was not estimated from backscatter below 30 m, so the final nearshore biomass estimates excludes a small amount of biomass that is likely attributed to Northern Anchovy and Pacific Herring.  
+
+<!-- CPS backscatter deeper than 30 m was assumed to be Northern Anchovy or Pacific Herring with length compositions corresponding to the nearest purse-seine set or trawl cluster containing either or both of those two species and used to estimate biomass density. Biomass densities from the two depth strata were summed vertically and used to estimate biomass.   -->
+
+<!-- (**Fig. \@ref(fig:plot-thermocline-scb)**) -->
+
+\newpage
+
+(ref:tx-biom-dens) Log-transformed biomass density + 1 ($t\,\mathrm{nmi}^{-2}$) by transect versus latitude (easternmost portion of each transect) and strata (shaded regions; outline indicates stratum number) used to estimate biomass and abundance for each species in the core region surveyed by _`r survey.vessel`_. Data labels (blue numbers) correspond to transects with positive biomass ($\log_{e}(t+1)$ > 0). Transect spacing (nmi; point color), and subpopulation breaks for Northern Anchovy and Pacific Sardine (red dashed lines and text) are indicated.  
+
+```{r tx-biom-dens,fig.cap='(ref:tx-biom-dens)',out.width='7in',fig.pos='H'}
+include_graphics(here("Figs/fig_biomass_density_transect_lat.png"))
+
+# Strata with no outline were not included because of too few specimens (< `r nIndiv.min` individuals), trawl clusters (< `r nClusters.min` clusters), or both. 
+```  
+
+\newpage
+
+(ref:transects-and-habitat-all) Summary of all core- and nearshore-region transects, in relation to the potential habitat for the northern subpopulation of Pacific Sardine, as sampled by _`r survey.vessel`_ (red), _Long Beach Carnage_ (cyan), and _Lisa Marie_ (yellow). The habitat is temporally aggregated using an average of the habitat centered ±2° around each vessel during the survey. Areas in white correspond to no available data (e.g., when cloud coverage prevented satellite-sensed observations).
+
+```{r transects-and-habitat-all,fig.cap='(ref:transects-and-habitat-all)',out.width = '6in',fig.align='center',fig.pos='H',eval=TRUE}
+if (file.exists(here("Images/img_sardine_habitat_composite_2407RL_newModel_AllVessels.png"))) {
+  include_graphics(here("Images/img_sardine_habitat_composite_2407RL_newModel_AllVessels.png"))
+  
+} else {
+  print("No habitat map present.")
+}
+```
+
+\newpage
+
+(ref:plot-thermocline-scb) Temperature versus depth for UCTD casts conducted in the SCB during summer 2023. The dashed horizontal line indicates the average estimated depth of the thermocline throughout the SCB.
+
+```{r plot-thermocline-scb,fig.cap='(ref:plot-thermocline-scb)',out.width='8in',fig.pos='H',eval=FALSE}
+# # Load UCTD data from the entire survey
+# load(file = here("Data/UCTD/uctd_data.Rdata"))
+# 
+# # Subset casts S of Pt. Conception
+# uctd.hdr.scb <- filter(all.uctd.hdr, lat < 34.3)
+# 
+# uctd.casts.scb <- all.uctd.casts %>%
+#   filter(cast %in% uctd.hdr.scb$cast)
+# 
+# # Plot temperature v depth
+# uctd.T <- ggplot(data = uctd.casts.scb,
+#                  aes(T, Z, group = cast, colour = factor(cast))) +
+#   geom_path(alpha = 0.75) +
+#   geom_hline(yintercept = -30, linetype = "dashed") +
+#   xlab("\nTemperature (C)") + ylab("Depth (m)\n") +
+#   scale_x_continuous(limits = c(round(min(uctd.casts.scb$T),0) - 1,
+#                                 round(max(uctd.casts.scb$T),0) + 1),
+#                      breaks = seq(round(min(uctd.casts.scb$T),0) - 1,
+#                                   round(max(uctd.casts.scb$T), 0) + 1, 2),
+#                      expand = c(0,0)) +
+#   scale_y_continuous(limits = c(round(min(uctd.casts.scb$Z), digits = -1),0),
+#                      breaks = seq(round(min(uctd.casts.scb$Z), digits = -1), 0, 20),
+#                      expand = c(0,0)) +
+#   theme_bw() +
+#   theme(panel.grid.major = element_line(linewidth = 0.75),
+#         legend.position = "none",
+#         strip.background.x = element_blank(),
+#         strip.text.x = element_text(face = "bold"))
+# 
+# # Save plot
+# ggsave(uctd.T, file = here("Figs/fig_uctd_T_v_Z_2307RL.png"))
+# 
+# # Include plot
+# include_graphics(here("Figs/fig_uctd_T_v_Z_2307RL.png"))
+```
+
+### Biomass and sampling precision estimation {#methods-biomass-and-precision}  
+
+For each stratum and subpopulation, the biomass ($\hat{B}$; kg) of each species was estimated by: 
+
+\begin{equation}
+\hat{B} = A \times \hat{D}\text{, }
+(\#eq:biomass-mean)
+\end{equation}
+
+where $A$ is the stratum area (nmi^2^) and $\hat{D}$ is the estimated mean biomass density (kg nmi^-2^):
+
+\begin{equation}
+\hat{D} = \frac{\sum_{l=1}^{k}\overline{\rho}_{w,l} c_l}{\sum_{l=1}^{k}c_l}\text{, }
+(\#eq:biomass-mean-density)
+\end{equation}
+
+where $\overline{\rho}_{w,l}$ is the mean biomass density of the species on transect $l$, $c_l$ is the transect length, and $k$ is the total number of transects. The variance of $\hat{B}$ is a function of the variability of the transect-mean densities and associated lengths. Treating transects as replicate samples of the underlying population [@Simmonds1996], the variance was calculated using bootstrap resampling [@Efron1981] based on transects as sampling units. Provided that each stratum has independent and identically-distributed transect means (i.e., densities on nearby transects are not correlated, and they share the same statistical distribution), bootstrap or other random-sampling estimators provide asymptotically unbiased estimates of variance.
+
+The 95% confidence intervals (CI~95%~) for the mean biomass densities ($\hat{D}$) were estimated as the 0.025 and 0.975 percentiles of the distribution of `r boot.num` bootstrap survey-mean biomass densities. Coefficient of variation (CV, %) values were obtained by dividing the bootstrapped standard error by the mean estimate [@Efron1981]. Total biomass in the survey area was estimated as the sum of the biomasses in each stratum, and the associated sampling variance was calculated as the sum of the variances across strata.  
+
+### Abundance- and biomass-at-length estimation {#methods-abundance-at-length}  
+
+The numerical densities by length class (**Section \@ref(methods-trawl-clustering)**) were averaged for each stratum in a similar way for that used for biomass (Equation \@ref(eq:biomass-mean-density)), and multiplied by the stratum area to obtain abundance per length class.  
+
+### Percent biomass per cluster contribution {#methods-cluster-biomass-density}  
+
+The percent contribution of each cluster to the estimated abundance in a stratum (**Appendix \@ref(appendix-cluster-length-percent)**) was calculated as:  
+
+\begin{equation}
+\frac{\Sigma_{i = 1}^{l}\overline{\rho}_{ci}}{\Sigma_{c=1}^{C}\Sigma_{i=1}^{l}\overline{\rho}_{ci}}{\text{,}}
+(\#eq:pct-acoustic-biomass)
+\end{equation}
+
+where $\overline{\rho}_{ci}$ is the numerical density in interval $i$ represented by the nearest trawl cluster $c$.  
+
+\newpage  
+
+# Results {#results}
+
+## Sampling effort and allocation {#results-sampling-effort}  
+
+```{r summ-survey-distances}
+# Summarise survey distance (nmi) by vessel
+## Core survey area
+dist.summ <- nasc.summ %>%
+  mutate(vessel = case_when(
+    str_detect(transect.name, "RL")  ~ "RL",
+    str_detect(transect.name, "SD")  ~ "SD",
+    str_detect(transect.name, "LBC") ~ "LBC",
+    str_detect(transect.name, "LM")  ~ "LM",
+    str_detect(transect.name, "SH")  ~ "SH",
+    TRUE ~ "Other")) %>% 
+  group_by(vessel) %>% 
+  summarise(distance = round(sum(distance)),
+            n.tx     = n(),
+            mean.tx.dist = distance/n.tx)
+
+## Nearshore survey area
+if (exists("nasc.summ.ns")) {
+  dist.summ.ns <- nasc.summ.ns %>%
+    mutate(vessel = case_when(
+      str_detect(transect.name, "RL")  ~ "RL",
+      str_detect(transect.name, "SD")  ~ "SD",
+      str_detect(transect.name, "LBC") ~ "LBC",
+      str_detect(transect.name, "LM")  ~ "LM",
+      str_detect(transect.name, "SH")  ~ "SH",
+      TRUE ~ "Other")) %>% 
+    group_by(vessel) %>% 
+    summarise(distance = round(sum(distance)),
+              n.tx     = n(),
+              mean.tx.dist = distance/n.tx)  
+}
+
+## Offshore survey area
+if (exists("nasc.summ.os")) {
+  dist.summ.os <- nasc.summ.os %>%
+    mutate(vessel = case_when(
+      str_detect(transect.name, "RL")  ~ "RL",
+      str_detect(transect.name, "SD")  ~ "SD",
+      str_detect(transect.name, "LBC") ~ "LBC",
+      str_detect(transect.name, "LM")  ~ "LM",
+      str_detect(transect.name, "SH")  ~ "SH",
+      TRUE ~ "Other")) %>% 
+    group_by(vessel) %>% 
+    summarise(distance = round(sum(distance)),
+              n.tx     = n(),
+              mean.tx.dist = distance/n.tx)
+}
+```
+
+```{r load-nearshore-nasc-summary}
+if ("Nearshore" %in% estimate.regions) {
+  load(here("Output/purse_seine_sets.Rdata"))
+  load(here("Output/nasc_summ_tx_ns.Rdata"))
+  
+  nasc.summ.lbc.ns <- filter(nasc.summ.ns, vessel.name == "LBC")
+  nasc.summ.lm.ns  <- filter(nasc.summ.ns, vessel.name == "LM") 
+}
+``` 
+
+```{r nav-summary}
+# Summarize Lasker days at sea
+if (file.exists(here("Data/Nav/nav_data_raw.rds"))) {
+  nav.rl <- readRDS(here("Data/Nav/nav_data_raw.rds"))
+  das.rl <- n_distinct(date(nav.rl$time))
+}
+
+# Summarize Shimada days at sea
+if (file.exists(here("Data/Nav/nav_data_raw_sh.rds"))) {
+  nav.sh <- readRDS(here("Data/Nav/nav_data_raw_sh.rds"))
+  das.sh <- n_distinct(date(nav.sh$time))
+}
+
+# Summarize Lisa Marie days at sea
+if (file.exists(here("Data/Nav/nav_vessel_lm.rds"))) {
+  nav.lm <- readRDS(here("Data/Nav/nav_vessel_lm.rds"))
+  das.lm <- n_distinct(date(nav.lm$datetime))
+}
+# Summarize Long Beach Carnage days at sea
+if (file.exists(here("Data/Nav/nav_vessel_lbc.rds"))) {
+  nav.lbc <- readRDS(here("Data/Nav/nav_vessel_lbc.rds"))
+  das.lbc <- n_distinct(date(nav.lbc$datetime))
+}
+
+# Summarize Saildrone days at sea
+if (file.exists(here("Data/Nav/nav_data_saildrone.Rdata"))) {
+  load(here("Data/Nav/nav_data_saildrone.Rdata"))
+  
+  das.sd <- nav.sd %>% 
+    group_by(saildrone) %>% 
+    summarise(das = n_distinct(date(datetime)))
+}
+```
+
+```{r summarise-seine-catch,eval=TRUE}
+if (exists("set.lengths")) {
+  # Summarise Lisa Marie catch
+  seine.summ.lm <- set.lengths %>% 
+    filter(vessel.name == "LM") %>% 
+    group_by(scientificName) %>% 
+    summarise(
+      total.wt = sum(weightg)/1000,
+      total.ct = n()
+    )
+  
+  # Summarise Long Beach Carnage catch
+  seine.summ.lbc <- set.lengths %>% 
+    filter(vessel.name == "LBC", landing != 160) %>% 
+    group_by(scientificName) %>%
+    summarise(
+      total.wt = sum(weightg)/1000,
+      total.ct = n()
+    )
+}
+
+if (exists("sets")) {
+  ## Summarize sets by vessel using `sets`
+  set.summ <- sets %>% 
+    group_by(vessel.name) %>% 
+    tally()  
+}
+```
+
+At the beginning of Leg 1, `r num2words(5)` days at sea (DAS) were allocated for drills, training, additional sea trials with the multi-function trawl (MFT) net system, and underway echosounder calibrations (see below).  
+
+The core region of the `r tolower(survey.season)` `r survey.year` survey spanned the continental shelf from the Punta Eugenia, Baja California, Mexico to Cape Scott, Vancouver Island, between `r format(ymd(erddap.survey.start),"%d %B")` and `r format(ymd(erddap.survey.end),"%d %B %Y")`, and included most of the potential habitat for the northern subpopulation of Pacific Sardine at the time of the survey^[https://coastwatch.pfeg.noaa.gov/erddap/griddap/sardine_habitat_modis.html]. In this region, _`r survey.vessel`_ (`r das.rl-5` DAS) sampled `r nrow(nasc.summ)` east-west transects totaling `r prettyNum(sum(nasc.summ$distance), digits = 1, big.mark = ",")` nmi (**Fig. \@ref(fig:nasc-trawl)**). Catches from a total of `r nrow(haul)` nighttime surface trawls were combined into `r n_distinct(haul$cluster)` trawl clusters. In the core region, one to `r num2words(max(as.numeric(be$Stratum), na.rm = TRUE))` post-survey strata were defined by their transect spacing and the densities of biomass attributed to each species. 
+
+The nearshore region spanned an area from 5-m depth to approximately 5 nmi from the continental coast, or 2.5 nmi from the Santa Cruz and Santa Catalina Islands, between San Diego and Cape Flattery. _Long Beach Carnage_ (`r das.lbc` DAS) surveyed from approximately San Diego to Ragged Point along the Big Sur coast, and around the Santa Cruz and Santa Catalina Islands, with `r nrow(nasc.summ.lbc.ns)` east-west transects totaling `r sprintf("%.0f",sum(nasc.summ.lbc.ns$distance))` nmi and `r set.summ$n[set.summ$vessel.name == "LBC"]` purse-seine sets (**Fig. \@ref(fig:nasc-seine-lbc)**). _Lisa Marie_ (`r das.lm` DAS) surveyed from approximately Pacific Grove, CA to Cape Flattery, WA with `r nrow(nasc.summ.lm.ns)` east-west transects totaling `r sprintf("%.0f",sum(nasc.summ.lm.ns$distance))` nmi and `r set.summ$n[set.summ$vessel.name == "LM"]` purse-seine sets (**Fig. \@ref(fig:nasc-seine-lm)**). In the nearshore region, one to `r num2words(max(as.numeric(be.ns$Stratum),na.rm = TRUE))` post-survey strata were defined by their transect spacing and the densities of biomass attributed to each species.
+
+Biomasses and abundances were estimated for each species and subpopulation in both the core and nearshore survey regions. The total biomass for each subpopulation within the survey region was estimated as the sum of its biomasses in the core and nearshore regions.  
+
+**Leg I**
+
+*Multi-Function Trawl (MFT) Net Testing*  
+
+Leg I aboard _Lasker_ departed from 10th Avenue Marine Terminal in San Diego, CA at 19:30 (all times UTC) on June 25, 2024. The first day consisted of drills, shipboard Operational Readiness Training (ORT), and equipment setup. Prior to sailing, the ship underwent a refit of its entire network to a new Fortinet solution, as part of OMAO's Ocean Data Lake initiative. The next five days (26-30 June) were spent testing the new Multi-Function Trawl (MFT) net and familiarizing personnel with its operations. On 27 June, the Cetacean Health and Life History Program from SWFSC's Marine Mammal and Turtle Division (MMTD) rendezvoused with _Lasker_ outside San Diego Bay to conduct drone footage of the MFT during operations. On 29 June, Greg Shaughnessey (Ocean Gold Seafood, Inc.) and Seamus Melly (Swan Nets) departed _Lasker_ via a small boat. On 30 June, another small-boat transfer was conducted to swap personnel for the remainder of Leg 1. During the transfer, _Lasker_ conducted a calibration of the EC150-3C ADCP at 32.602 N, 117.287 W following the protocols as prescribed by Kongsberg, which involved the ship moving in multiple clockwise and counterclockwise circles. After completing a successful calibration, _Lasker_ then transited to 32.542 N / 117.184 W and dropped anchor in approximately 30-m of water. Once anchored, calibrations of the EC150-3C echosounder and ME70 multibeam sonar were conducted. Upon completion of the calibrations, and after the small boat had returned, _Lasker_ pulled up anchor and began its transit south to Baja California, Mexico, where it would begin the ATM survey.
+
+*ATM survey*
+
+On the morning of 2 July, _Lasker_ commenced acoustic sampling on Transect 001 in Sebastián Vizcaíno Bay to officially begin the 2024 survey. Acoustic and trawl sampling in Baja California, MX proceeded northward along the 20-nmi-spaced transects. On 7 July, _Lasker_ completed the last transect in Mexico, Transect 027C. Between 7-16 July, _Lasker_ continued sampling in the SCB. Due to the long transect lines in the SCB, regional sampling was conducted to ensure adequate biological sampling in both the inshore and offshore regions. On 16 July, _Lasker_ completed the final sampling of Leg I off Huntington Beach, CA. In total, Leg I sampled all transects from Transects 001 to 040. At 05:00 on 17 July, after completing a single trawl for the final evening, _Lasker_ began its transit back to San Diego, CA, arriving at 10th Avenue Marine Terminal at 14:50.
+
+*Nearshore*
+
+On 8 July, _Long Beach Carnage_ was mobilized with EK80 echosounders at Point Loma Sportfishing in San Diego, CA. From 9 to 18 July, _Long Beach Carnage_ sampled nearshore transects 1 to 36, between San Diego and Point Conception, including around Santa Catalina Island.
+
+**Leg II**  
+
+Leg II aboard _Lasker_ departed on Monday, 22 July at 21:30 from 10th Avenue Marine Terminal in San Diego. At around 13:00 on 23 July, _Lasker_ resumed acoustic sampling along the nearshore portion of Transect 041 off Huntington Beach. At ~13:00 on 31 July, a lander containing a WBAT and Aural-M2 was recovered off Point Conception, and at ~14:00 a new lander was deployed in the same area (34.439 N / 120.548 W). On 6 August, _Lasker_ transited to Santa Cruz, CA to find calm seas and improved visibility for troubleshooting problems with the X-band radar; ET Trevathan successfully replaced the brushes in the radar antenna motor and the survey resumed the following day with minimal impact to sampling. At ~06:00 on 12 August, acoustic sampling was completed along Transect 075 off Bodega Bay, CA, and at 14:30 _Lasker_ arrived at Pier 76 in San Francisco, CA to conclude Leg II.
+
+*Nearshore*
+
+From 22 to 25 July, _Long Beach Carnage_ sampled nearshore transects 37 to 48, between Point Conception and Morro Bay, including around Santa Cruz Island. Then, from 2 to 3 August, _Long Beach Carnage_ sampled nearshore transects 49 to 54. On 3 August, _Long Beach Carnage_ docked in Monterey, CA, where the acoustic equipment was demobilized for transport back to San Diego, CA.
+
+**Leg III** 
+
+Leg III aboard _Lasker_ departed at 19:30 on Saturday, 17 August from Pier 96 in San Francisco, CA. The first day consisted of drills and shipboard ORT activities, followed by two nighttime trawls in the vicinity of Bodega Canyon. Acoustic sampling then resumed at sunrise on 18 August along Transect 076. On 28 and 29 August, inclement weather precluded trawl sampling.  Moreover, on the evening of 28 August, _Lasker_ was requested by the U.S. Coast Guard to watch over the distressed sailboat _Sundance_ until the following morning. On 31 August, _Lasker_ commenced regional sampling, in part to obtain both inshore and offshore trawls to enable comparative biosampling with _Lisa Marie_. On 6 September, _Lasker_ completed partial acoustic sampling of Transect 124, just outside the mouth of the Columbia River, then conducted a final trawl just north of Tillamook Head. _Lasker_ then returned to MOC-P in Newport, OR at 23:00 on 7 September to conclude Leg III.
+
+*Nearshore*
+
+From 7 to 25 August, _Lisa Marie_ sampled nearshore transects 66 to 151, between Monterey, CA and the WA/OR border, returning to port in Westport, WA on 26 August. Then, from 31 August to 6 September, _Lisa Marie_ conducted comparative purse seine sets in close proximity, in both space and time, to _Lasker_ nighttime trawls. Finally, from 7 to 11 September, _Lisa Marie_ sampled nearshore transects 152 to 171, between the WA/OR border and Cape Flattery, WA, to conclude the nearshore survey.
+
+**Leg IV** 
+
+Leg IV aboard _Lasker_ departed from MOC-P in Newport, OR at 16:30 on 13 September after a one-day delay awaiting arrival of an augmenting steward. The first day included drills followed by transiting to and beginning sampling on Transect 124, which had been partially sampled during Leg III. _Lasker_ then continued sampling northward, entering Canadian waters on 21 September to conduct transects off Vancouver Island. Due to time and weather constraints, sampling off Vancouver Island was only conducted on compulsory transects, spaced 20-nmi apart. On 23 September, after acoustically sampling and conducting trawls on Transect 149, _Lasker_ transited to the northernmost transect (Transect 155) off Vancouver Island and resumed sampling from north to south. This decision was made due to an impending weather system, and would optimize sampling effort before _Lasker_ would need to vacate the region. On 24 September, _Lasker_ completed its final transect of the survey, Transect 151, and conducted one last trawl, before transiting to Newport, OR, where _Lasker_ arrived at ~17:00 on 26 September.
+
+## Acoustic backscatter {#results-backscatter-distribution} 
+
+Acoustic backscatter ascribed to CPS was observed throughout the latitudinal range of the core survey area (**Fig. \@ref(fig:nasc-trawl)a**), but was greatest between San Diego and San Francisco. Acoustic backscatter was present from the shore to the shelf break, but was generally greater closer to shore. Zero-biomass intervals were observed at the offshore end of each transect in the core region. Greater than `r cum.biomass.limit*100`% of the biomass for each species was apportioned using catch data from trawl clusters conducted within ~25 nmi (**Fig. \@ref(fig:biomass-cluster-distance)**).  
+
+Acoustic backscatter ascribed to CPS was also observed throughout the nearshore survey area, but was most prevalent along mainland and Channel Island transects sampled by _Long Beach Carnage_ between San Diego and Ragged Point (**Fig. \@ref(fig:nasc-seine-lbc)a**), and along transects sampled by _Lisa Marie_ between Santa Cruz and San Francisco, and north of Cape Mendocino (**Fig. \@ref(fig:nasc-seine-lm)a**).
+
+## Trawl catch {#results-trawl-catch}  
+
+Trawl catches from _`r survey.vessel`_ were composed of mostly Northern Anchovy between Punta Eugenia and San Francisco, and Jack Mackerel farther north (**Fig. \@ref(fig:nasc-trawl)b**). Pacific Herring were also prevalent in trawl catches between Newport and Cape Flattery. Some Pacific Sardine and Pacific Mackerel were present in trawl clusters offshore in the SCB and close to shore between Newport and Astoria, OR off the Columbia River. Overall, the `r nrow(haul)` trawls captured a combined `r prettyNum(sum(cluster.summ.wt$AllCPS),big.mark=",",digits=3)` kg of CPS (`r prettyNum(sum(cluster.summ.wt$'Anchovy'),big.mark=",",digits=3)` kg of Northern Anchovy, `r prettyNum(sum(cluster.summ.wt$'JackMack'),big.mark=",",digits=3)` kg of Jack Mackerel, `r prettyNum(sum(cluster.summ.wt$'PacHerring'),big.mark=",",digits=3)` kg of Pacific Herring, `r prettyNum(sum(cluster.summ.wt$'Sardine'),big.mark=",",digits=3)` kg of Pacific Sardine, `r prettyNum(sum(cluster.summ.wt$'PacMack'),big.mark=",",digits=3)` kg of Pacific Mackerel, and `r prettyNum(sum(cluster.summ.wt$'RndHerring'),big.mark=",",digits=3)` kg of Round Herring).  
+
+## Purse-seine catch {#results-seine-catch}  
+### _Long Beach Carnage_  
+
+Purse-seine catches from _Long Beach Carnage_ in the nearshore region were composed mostly of Pacific Sardine and Pacific Mackerel (**Fig. \@ref(fig:nasc-seine-lbc)b**). In general, Pacific Mackerel were more prevalent in samples collected along the mainland coast south of Los Angeles, CA and around Santa Catalina Island. Relatively few Jack Mackerel, Northern Anchovy, and Round Herring were collected in purse-seine samples collected by _Long Beach Carnage_ (**Fig. \@ref(fig:nasc-seine-lbc)b**). Overall, dip-net samples from `r set.summ$n[set.summ$vessel.name == "LBC"]` seines totaled `r prettyNum(sum(seine.summ.lbc$total.wt),big.mark=",",digits=3)` kg of CPS (`r prettyNum(seine.summ.lbc$total.wt[seine.summ.lbc$scientificName == "Sardinops sagax"],big.mark=",",digits=3)` kg of Pacific Sardine, `r prettyNum(seine.summ.lbc$total.wt[seine.summ.lbc$scientificName == "Scomber japonicus"],big.mark=",",digits=3)` kg of Pacific Mackerel, `r prettyNum(seine.summ.lbc$total.wt[seine.summ.lbc$scientificName == "Engraulis mordax"],big.mark=",",digits=2)` kg of Northern Anchovy, `r prettyNum(seine.summ.lbc$total.wt[seine.summ.lbc$scientificName == "Trachurus symmetricus"],big.mark=",",digits=2)` kg of Jack Mackerel, and `r prettyNum(seine.summ.lbc$total.wt[seine.summ.lbc$scientificName == "Etrumeus acuminatus"],big.mark=",",digits=2)` kg of Round Herring).  
+
+### _Lisa Marie_ {#results-seine-catch-lm}  
+
+Purse seine catches from _Lisa Marie_ in the nearshore were composed mostly of Pacific Herring, except a few catches of Pacific Sardine between Monterey and San Francisco and a few catches of Jack Mackerel and Pacific Mackerel between Cape Blanco and Newport (**Fig. \@ref(fig:nasc-seine-lm)b**). Purse seine sampling between Monterey and Cape Mendocino was sparse due to few CPS targets, the presence or marine mammals that did not permit the deployment of the purse seine gear, or both. Many of the purse seine sets north of Cape Mendocino contained no CPS (**Fig. \@ref(fig:nasc-seine-lm)b**). Overall, the dip-net samples from `r set.summ$n[set.summ$vessel.name == "LM"]` purse-seine sets totaled `r prettyNum(sum(seine.summ.lm$total.wt),big.mark=",",digits=3)` kg of CPS (`r prettyNum(seine.summ.lm$total.wt[seine.summ.lm$scientificName == "Trachurus symmetricus"],big.mark=",",digits=3)` kg of Jack Mackerel, `r prettyNum(seine.summ.lm$total.wt[seine.summ.lm$scientificName == "Scomber japonicus"],big.mark=",",digits=3)` kg of Pacific Mackerel, `r prettyNum(seine.summ.lm$total.wt[seine.summ.lm$scientificName == "Sardinops sagax"],big.mark=",",digits=3)` kg of Pacific Sardine, `r prettyNum(seine.summ.lm$total.wt[seine.summ.lm$scientificName == "Clupea pallasii"],big.mark=",",digits=3)` kg of Pacific Herring, and `r prettyNum(seine.summ.lm$total.wt[seine.summ.lm$scientificName == "Engraulis mordax"],big.mark=",",digits=3)` kg of Northern Anchovy). 
+
+\newpage
+\blandscape
+
+(ref:biomass-cluster-distance) Proportion (top) and cumulative proportion (bottom) of biomass of each CPS species versus distance to the nearest positive trawl cluster sampled by _`r survey.vessel`_. Dashed vertical lines (bottom) represent the cluster distance where cumulative biomass equals `r cum.biomass.limit*100`%. Note: these results are not separated by subpopulation.
+
+```{r biomass-cluster-distance,fig.cap='(ref:biomass-cluster-distance)',out.width='9in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_distance_cumulative_biomass.png"))
+```  
+
+\newpage  
+
+(ref:nasc-trawl) Spatial distributions of: a) 38-kHz vertically integrated backscattering coefficients ($s_A$, m^2^ nmi^-2^;  averaged over 2000-m distance intervals) ascribed to CPS and b) proportion of acoustic backscatter from CPS in trawl clusters sampled by _`r survey.vessel`_.
+
+```{r nasc-trawl, fig.cap='(ref:nasc-trawl)',out.width='8.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_nasc_acoustic_proportion.png"))
+```  
+
+\newpage
+
+(ref:nasc-seine-lbc) Nearshore transects sampled by _Long Beach Carnage_ overlaid with the distributions of: a) 38-kHz integrated backscattering coefficients ($s_A$, m^2^ nmi^-2^; averaged over 2000-m distance intervals) ascribed to CPS; and b) the proportions of acoustic backscatter from CPS in each purse-seine catch. Black points indicate purse-seine sets with no CPS present. Species with low catch weights may not be visible at this scale.
+
+```{r nasc-seine-lbc, fig.cap='(ref:nasc-seine-lbc)', out.width='9in', fig.pos='H'}
+if (file.exists(here("Figs/fig_nasc_seine_proportion_set_wt_LBC.png"))) {
+  include_graphics(here("Figs/fig_nasc_seine_proportion_set_wt_LBC.png"))  
+} else {
+  print("No Long Beach Carnage purse-seine sampling figure present.")
+}
+```  
+
+\elandscape
+\newpage  
+
+(ref:nasc-seine-lm) Nearshore survey transects sampled by _Lisa Marie_ overlaid with the distributions of: a) 38-kHz vertically integrated backscattering coefficients ($s_A$, m^2^ nmi^-2^; averaged over 2000-m distance intervals) ascribed to CPS; and b) the proportion of acoustic backscatter from CPS in each purse-seine catch. Black points indicate purse-seine sets with no CPS present. Species with low catch weights may not be visible at this scale.
+
+```{r nasc-seine-lm, fig.cap='(ref:nasc-seine-lm)', out.height='6.5in', fig.pos='H', eval=TRUE}
+if (file.exists(here("Figs/fig_nasc_seine_proportion_set_wt_LM.png"))) {
+  include_graphics(here("Figs/fig_nasc_seine_proportion_set_wt_LM.png"))  
+} else {
+  print("No Lisa Marie purse-seine sampling figure present.")
+}
+```  
+
+\newpage 
+
+(ref:nasc-prop-ns) Spatial distributions of: a) 38-kHz vertically integrated backscattering coefficients ($s_A$, m^2^ nmi^-2^; averaged over 2000-m distance intervals) ascribed to CPS from nearshore sampling; and b) proportions of CPS backscatter in trawl clusters (`r trawl.color` outline) and purse-seine sets (`r seine.color` outline) used to estimate biomasses in the nearshore region.
+
+```{r nasc-prop-ns, fig.cap='(ref:nasc-prop-ns)',out.width='6.5in',fig.pos='H',eval=FALSE}
+if (file.exists(here("Figs/fig_nasc_acoustic_cluster_ns.png"))) {
+  include_graphics(here("Figs/fig_nasc_acoustic_cluster_ns.png"))  
+} else {
+  print("No nearsure purse-seine/backscatter figure present.")
+}
+```
+
+\newpage
+
+```{r biomass-table-all,results='asis'}
+# Format bootstrap estimate tables
+be.table <- be  %>%
+  rename(Name = Species,
+         Number           = Stratum,
+         Transects        = nTransects,
+         Clusters         = nClusters,
+         Individuals      = nIndiv,
+         "$\\hat{B}$"     = Biomass,
+         SD               = biomass.sd,
+         CV               = biomass.cv,
+         "CI$_{L,95\\%}$" = lower.ci.B,
+         "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+  select(-SD)  
+
+if (exists("be.ns")) {
+  be.table.ns <- be.ns  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+    select(-SD)
+}
+
+if (exists("be.nse")) {
+  be.table.nse <- be.nse  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+    select(-SD)
+}
+
+if (exists("be.os")) {
+  be.table.os <- be.os  %>%
+    rename(Name = Species,
+           Number           = Stratum,
+           Transects        = nTransects,
+           Clusters         = nClusters,
+           Individuals      = nIndiv,
+           "$\\hat{B}$"     = Biomass,
+           SD               = biomass.sd,
+           CV               = biomass.cv,
+           "CI$_{L,95\\%}$" = lower.ci.B,
+           "CI$_{U,95\\%}$" = upper.ci.B) %>%
+    select(-SD)  
+}
+
+# Format summary table
+be.table.summ <- be.all.summ %>% 
+  rename(Name = Species,
+         # Number           = Stratum,
+         Transects        = nTransects,
+         Clusters         = nClusters,
+         Individuals      = nIndiv,
+         "$\\hat{B}$"     = Biomass,
+         SD               = biomass.sd,
+         CV               = biomass.cv,
+         "CI$_{L,95\\%}$" = lower.ci.B,
+         "CI$_{U,95\\%}$" = upper.ci.B) %>% 
+  select(-SD)
+```  
+
+## Biomass distribution and demographics {#results-biomass-distribution}  
+
+The biomasses, distributions, and demographics for each species and subpopulation are for the survey area and period and therefore may not represent the entire population. All biomass estimates are in metric tons (t).  
+
+### Northern Anchovy {#results-anchovy}
+#### Northern subpopulation {#results-anchovy-northern}  
+\
+The total estimated biomass of the northern subpopulation of Northern Anchovy was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-n)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-n)**). $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Northern"]` to `r length.summ$L.max[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Northern"]` cm with a mode at 15 cm (**Table \@ref(tab:l-freq-summ-anch-n)**, **Fig. \@ref(fig:l-disagg-anch-n)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-n)**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Northern"] + be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Northern"]))*100,big.mark=",",digits=2)`% of the total biomass. Lengths in the nearshore region had a single mode at 15 cm (**Table \@ref(tab:l-freq-summ-anch-n)**; **Fig. \@ref(fig:l-disagg-anch-n)**). In both the core and nearshore regions, the subpopulation was sparsely distributed between Astoria and Cape Flattery (**Fig. \@ref(fig:biom-dens-anch-n)a, b**). 
+
+(ref:biomass-anch-n) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the northern subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-anch-n}
+
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Northern") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Engraulis_mordax_Northern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>%
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>%
+      merge_h(part = "header") %>%
+      align(align = "center",part = "header") %>%
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-anch-n)') %>%
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>%
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage  
+
+(ref:l-freq-summ-anch-n) Abundance estimates versus standard length ($L_S$, cm) for the northern subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-anch-n}
+# Print table for anchovy
+if ("Engraulis mordax" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Engraulis mordax", Stock == "Northern") %>% 
+    rename('$L_S$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center", part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-anch-n)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))  
+    }
+  }
+} else {
+  print("No anchovy present.")
+}
+```
+
+\newpage  
+
+(ref:biom-dens-anch-n) Biomass densities (colored points) of the northern subpopulation of Northern Anchovy (_Engraulis mordax_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Northern Anchovy in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-anch-n,fig.cap='(ref:biom-dens-anch-n)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Engraulis mordax-Northern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Engraulis mordax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_biomass_dens_Engraulis mordax-Northern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Engraulis mordax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+
+\newpage  
+
+(ref:l-disagg-anch-n) Abundance estimates versus standard length ($L_S$, upper panels) and biomass (t) versus $L_S$ (lower panels) for the northern subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions. Abundance and biomass in the nearshore region is negligible relative to the core region and not visible at this scale.
+
+```{r l-disagg-anch-n,fig.cap='(ref:l-disagg-anch-n)',out.height='7in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Engraulis mordax-Northern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Engraulis mordax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Engraulis mordax-Northern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Engraulis mordax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+
+\newpage 
+
+#### Central subpopulation {#results-anchovy-central}  
+\
+The total estimated biomass of the central subpopulation of Northern Anchovy was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-c)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=4)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-c)**). The subpopulation was distributed throughout most of the survey area from San Diego to San Francisco, but was most abundant north of Pt. Conception (**Fig. \@ref(fig:biom-dens-anch-c)a**). $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Central"]` to `r length.summ$L.max[length.summ$scientificName == 'Engraulis mordax' & length.summ$stock == "Central"]` cm with a modes at 6 and 13 cm (**Table \@ref(tab:l-freq-summ-anch-c)**, **Fig. \@ref(fig:l-disagg-anch-c)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-anch-c)**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"] / (be.all.ns$Biomass[be.all.ns$Species == 'Engraulis mordax' & be.all.ns$Stock == "Central"] + be.all$Biomass[be.all$Species == 'Engraulis mordax' & be.all$Stock == "Central"]))*100,big.mark=",",digits=2)`% of the total biomass. The biomass was sparsely distributed between Long Beach and Bodega Bay, but was greatest near Morro Bay (**Fig. \@ref(fig:biom-dens-anch-c)b**). The nearshore length distribution had two modes at 8 and 13 cm (**Table \@ref(tab:l-freq-summ-anch-c)**, **Fig. \@ref(fig:l-disagg-anch-c)**).
+
+(ref:biomass-anch-c) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the central subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-anch-c}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Engraulis mordax", Stock == "Central") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Engraulis mordax", Stock == "Central") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Engraulis_mordax_Central.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-anch-c)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage  
+
+(ref:l-freq-summ-anch-c) Abundance estimates versus standard length ($L_S$, cm) for the central subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-anch-c}
+# Print table for anchovy
+if ("Engraulis mordax" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Engraulis mordax", Stock == "Central") %>% 
+    rename('$L_S$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center", part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-anch-c)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))
+    }
+  }
+} else {
+  print("No anchovy present.")
+}
+```
+
+\newpage  
+
+(ref:biom-dens-anch-c) Biomass densities (colored points) of central subpopulation of Northern Anchovy (_Engraulis mordax_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Northern Anchovy in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-anch-c,fig.cap='(ref:biom-dens-anch-c)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Engraulis mordax-Central.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Engraulis mordax-Central.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_biomass_dens_Engraulis mordax-Central.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Engraulis mordax-Central.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+
+\newpage  
+
+(ref:l-disagg-anch-c) Abundance estimates versus standard length ($L_S$, upper panels) and biomass (t) versus $L_S$ (lower panels) for the central subpopulation of Northern Anchovy (_Engraulis mordax_) in the core and nearshore survey regions.
+
+```{r l-disagg-anch-c,fig.cap='(ref:l-disagg-anch-c)',out.height='7in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Engraulis mordax-Central.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Engraulis mordax-Central.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Engraulis mordax-Central.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Engraulis mordax-Central.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+\newpage  
+
+### Pacific Sardine {#results-sardine} 
+#### Northern subpopulation {#results-sardine-northern}  
+\
+The total estimated biomass of the northern subpopulation of Pacific Sardine was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-n)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-n)**), and was observed between Pt. Conception and Monterey, and between Astoria and Cape Flattery (**Fig. \@ref(fig:biom-dens-sar-n)a**). $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Northern"]` to `r length.summ$L.max[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == 'Northern']` cm with modes at 9 and 17 cm (**Table \@ref(tab:l-freq-summ-sar-n)**, **Fig. \@ref(fig:l-disagg-sar-n)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-n)**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Northern"] + be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Northern"]))*100,big.mark=",",digits=3)`% of the total biomass. Biomass was distributed between Pt. Conception and San Francisco (**Fig. \@ref(fig:biom-dens-sar-n)b**). Lengths in the nearshore region had a mode at 18 cm  (**Table \@ref(tab:l-freq-summ-sar-n)**, **Fig. \@ref(fig:l-disagg-sar-n)**).
+
+(ref:biomass-sar-n) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the northern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-sar-n}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Sardinops sagax", Stock == "Northern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Sardinops sagax", Stock == "Northern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Northern") %>%
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Sardinops_sagax_Northern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-sar-n)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage
+
+(ref:l-freq-summ-sar-n) Abundance estimates versus standard length ($L_S$, cm) for the northern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-sar-n}
+# Print table for sardine
+if ("Sardinops sagax" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Sardinops sagax", Stock == "Northern") %>% 
+    rename('$L_S$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-sar-n)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))   
+    }
+  }
+} else {
+  print("No sardine present.")
+}
+```  
+
+\newpage
+
+(ref:biom-dens-sar-n) Biomass densities (colored points) of the northern subpopulation of Pacific Sardine (_Sardinops sagax_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Pacific Sardine in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-sar-n,fig.cap='(ref:biom-dens-sar-n)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Sardinops sagax-Northern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Sardinops sagax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_biomass_dens_Sardinops sagax-Northern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Sardinops sagax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+
+\newpage  
+
+(ref:l-disagg-sar-n) Estimated abundance (upper panel) and biomass (lower panel) versus standard length ($L_S$, cm) for the northern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions. Note: the abundance and biomass in the core region are difficult to see at this scale.
+
+```{r l-disagg-sar-n,fig.cap='(ref:l-disagg-sar-n)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Sardinops sagax-Northern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Sardinops sagax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Sardinops sagax-Northern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Sardinops sagax-Northern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+
+\newpage
+
+#### Southern subpopulation {#results-sardine-southern}  
+\
+The total estimated biomass of the southern subpopulation of Pacific Sardine was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=4)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Sardinops sagax' & be.all.summ$Stock == "Southern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-s)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-s)**), and was distributed between Punta Eugenia and El Rosario off Baja CA and between San Diego and Long Beach in the SCB (**Fig. \@ref(fig:biom-dens-sar-s)a**). $L_S$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == "Southern"]` to `r length.summ$L.max[length.summ$scientificName == 'Sardinops sagax' & length.summ$stock == 'Southern']` cm with modes at 6 and 19 cm (**Table \@ref(tab:l-freq-summ-sar-s)**, **Fig. \@ref(fig:l-disagg-sar-s)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-sar-s)**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"] / (be.all.ns$Biomass[be.all.ns$Species == 'Sardinops sagax' & be.all.ns$Stock == "Southern"] + be.all$Biomass[be.all$Species == 'Sardinops sagax' & be.all$Stock == "Southern"]))*100,big.mark=",",digits=2)`% of the total biomass. The nearshore biomass was distributed along the mainland coast from San Diego to Pt. Conception and around Santa Cruz and Santa Catalina Islands. Lengths in the nearshore region had modes at 9 and 15 cm (**Table \@ref(tab:l-freq-summ-sar-s)**, **Fig. \@ref(fig:l-disagg-sar-s)**).
+
+(ref:biomass-sar-s) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for the southern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-sar-s}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Sardinops sagax", Stock == "Southern") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Sardinops sagax", Stock == "Southern") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Sardinops sagax", Stock == "Southern") %>%
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Sardinops_sagax_Southern.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-sar-s)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage
+
+(ref:l-freq-summ-sar-s) Abundance estimates versus standard length ($L_S$, cm) for the southern subpopulation of Pacific Sardine (_Sardinops sagax_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-sar-s}
+# Print table for sardine
+if ("Sardinops sagax" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Sardinops sagax", Stock == "Southern") %>% 
+    rename('$L_S$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-sar-s)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))   
+    }
+  }
+} else {
+  print("No sardine present.")
+}
+```  
+\newpage
+
+(ref:biom-dens-sar-s) Biomass densities (colored points) of the southern subpopulation of Pacific Sardine (_Sardinops sagax_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Pacific Sardine in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-sar-s,fig.cap='(ref:biom-dens-sar-s)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Sardinops sagax-Southern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Sardinops sagax-Southern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_biomass_dens_Sardinops sagax-Southern.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Sardinops sagax-Southern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+
+\newpage  
+
+(ref:l-disagg-sar-s) Estimated abundance (upper panels) and biomass (lower panels) versus standard length ($L_S$, cm) for the southern subpopulation of Pacific Sardine (_Sardinops sagax_)  in the core and nearshore survey regions.
+
+```{r l-disagg-sar-s,fig.cap='(ref:l-disagg-sar-s)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Sardinops sagax-Southern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Sardinops sagax-Southern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Sardinops sagax-Southern.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Sardinops sagax-Southern.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+\newpage
+
+### Pacific Mackerel {#results-mack}  
+
+The total estimated biomass of Pacific Mackerel was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-mack)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%) and was mostly located in the SCB and off central OR (**Fig. \@ref(fig:biom-dens-mack)a**). The distribution of $L_F$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Scomber japonicus']` to `r length.summ$L.max[length.summ$scientificName == 'Scomber japonicus']` cm with modes at 8, 17, and 37 cm (**Table \@ref(tab:l-freq-summ-mack)**, not visible in **Fig. \@ref(fig:l-disagg-mack)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Scomber japonicus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-mack)**, **Fig. \@ref(fig:biom-dens-mack)b**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Scomber japonicus'] + be.all$Biomass[be.all$Species == 'Scomber japonicus']))*100,big.mark=",",digits=3)`% of the total biomass, and was mostly present in along the mainland coast in the SCB and around Santa Cruz and Santa Catalina Islands. Lengths in the nearshore region had modes at 22 and 41 cm.
+
+(ref:biomass-mack) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Pacific Mackerel (_Scomber japonicus_) in nearshore survey region. Stratum areas are nmi^2^.
+
+```{r biomass-mack}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Scomber japonicus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Scomber japonicus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Scomber japonicus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Scomber_japonicus_all.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-mack)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>%
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage  
+
+(ref:l-freq-summ-mack) Abundance estimates versus fork length ($L_F$, cm) for Pacific Mackerel (_Scomber japonicus_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-mack}
+# Print table for mackerel
+if ("Scomber japonicus" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Scomber japonicus") %>% 
+    rename('$L_F$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-mack)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))   
+    }
+  }
+} else {
+  print("No mackerel present.")
+}
+``` 
+
+\newpage
+
+(ref:biom-dens-mack) Biomass densities (colored points) of Pacific Mackerel (_Scomber japonicus_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Pacific Mackerel in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-mack,fig.cap='(ref:biom-dens-mack)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Scomber japonicus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Scomber japonicus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_biomass_dens_Scomber japonicus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Scomber japonicus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+\newpage  
+
+(ref:l-disagg-mack) Estimated abundance (upper panels) and biomass (lower panels) versus fork length ($L_F$, cm) for Pacific Mackerel (_Scomber japonicus_)  in the core and nearshore survey regions.
+
+```{r l-disagg-mack,fig.cap='(ref:l-disagg-mack)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Scomber japonicus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Scomber japonicus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Scomber japonicus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Scomber japonicus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+\newpage
+
+### Jack Mackerel {#results-jack}  
+
+The total estimated biomass of Jack Mackerel was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-jack)**). In the core region, the biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=4)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-jack)**), was distributed throughout the entire survey area, but was greatest between Cape Mendocino and Cape Scott off Vancouver Island (**Fig. \@ref(fig:biom-dens-jack)a**). $L_F$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Trachurus symmetricus']` to `r length.summ$L.max[length.summ$scientificName == 'Trachurus symmetricus']` cm, with modes at 4, 12 and 41 cm. (**Table \@ref(tab:l-freq-summ-jack)**, **Fig. \@ref(fig:l-disagg-jack)**). In the nearshore region, the biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Trachurus symmetricus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-jack)**), comprising `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Trachurus symmetricus'] + be.all$Biomass[be.all$Species == 'Trachurus symmetricus']))*100,big.mark=",",digits=2)`% of the total biomass. Biomass was present throughout the nearshore survey area, but was greatest between Cape Mendocino and Astoria (**Fig. \@ref(fig:biom-dens-jack)b**). Lengths in the nearshore region had a mode at 4 cm and a broad distribution between 31 and 53 cm (**Table \@ref(tab:l-freq-summ-jack)**, **Fig. \@ref(fig:l-disagg-jack)**).  
+
+(ref:biomass-jack) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Jack Mackerel (_Trachurus symmetricus_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-jack}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Trachurus symmetricus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Trachurus symmetricus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Trachurus symmetricus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Trachurus_symmetricus_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-jack)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage  
+
+(ref:l-freq-summ-jack) Abundance estimates versus fork length ($L_F$, cm) for Jack Mackerel (_Trachurus symmetricus_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-jack}
+# Print table for mackerel
+if ("Trachurus symmetricus" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Trachurus symmetricus") %>% 
+    rename('$L_F$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-jack)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>%
+        row_spec(0, align = c("c"))
+    }
+  }
+} else {
+  print("No Jack Mackerel present.")
+}
+``` 
+
+\newpage
+
+(ref:biom-dens-jack) Biomass densities (colored points) of Jack Mackerel (_Trachurus symmetricus_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Jack Mackerel in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-jack,fig.cap='(ref:biom-dens-jack)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Trachurus symmetricus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Trachurus symmetricus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  
+  if (file.exists(here("Figs/fig_biomass_dens_Trachurus symmetricus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Trachurus symmetricus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+
+\newpage  
+
+(ref:l-disagg-jack) Estimated abundance (upper panel) and biomass (lower panel) versus fork length ($L_F$, cm) for Jack Mackerel (_Trachurus symmetricus_) in the core and nearshore survey regions.
+
+```{r l-disagg-jack,fig.cap='(ref:l-disagg-jack)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Trachurus symmetricus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Trachurus symmetricus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Trachurus symmetricus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Trachurus symmetricus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```  
+\newpage
+
+### Pacific Herring {#results-her}
+
+The total estimated biomass of Pacific Herring was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-her)**). In the core region, biomass was `r prettyNum(be.all$Biomass[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all$lower.ci.B[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all$upper.ci.B[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all$biomass.cv[be.all$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-her)**). It was distributed from approximately Florence, OR to central Vancouver Island (**Fig. \@ref(fig:biom-dens-her)a**). $L_F$ in the core region ranged from `r length.summ$L.min[length.summ$scientificName == 'Clupea pallasii']` to `r length.summ$L.max[length.summ$scientificName == 'Clupea pallasii']` cm, with modes at 9, 17, and 22 cm (**Table \@ref(tab:l-freq-summ-her)**, **Fig. \@ref(fig:l-disagg-her)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Clupea pallasii'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-her)**, **Fig. \@ref(fig:biom-dens-her)b**), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'] / (be.all.ns$Biomass[be.all.ns$Species == 'Clupea pallasii'] + be.all$Biomass[be.all$Species == 'Clupea pallasii']))*100,big.mark=",",digits=2)`% of the total biomass. It was distributed from San Francisco to Cape Flattery (**Fig. \@ref(fig:l-disagg-her)**), but was most abundant north of Newport. Lengths in the nearshore region had modes at 9 and 16 cm (**Table \@ref(tab:l-freq-summ-her)**, **Fig. \@ref(fig:l-disagg-her)**).
+
+(ref:biomass-her) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Pacific Herring (_Clupea pallasii_) in the core and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-her}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Clupea pallasii") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Clupea pallasii") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Clupea pallasii") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Clupea_pallasii_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-her)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+\newpage  
+
+(ref:l-freq-summ-her) Abundance estimates versus fork length ($L_F$, cm) for Pacific Herring (_Clupea pallasii_) in the core and nearshore survey regions.
+
+```{r l-freq-summ-her}
+# Print table for P. herring
+if ("Clupea pallasii" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Clupea pallasii") %>% 
+    rename('$L_F$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-her)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))   
+    }
+  }
+} else {
+  print("No Pacific Herring present.")
+}
+``` 
+
+\newpage
+
+(ref:biom-dens-her) Biomass densities (colored points) of Pacific Herring (_Clupea pallasii_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Pacific Herring in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-her,fig.cap='(ref:biom-dens-her)',out.width='6.5in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Clupea pallasii-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Clupea pallasii-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  
+  if (file.exists(here("Figs/fig_biomass_dens_Clupea pallasii-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Clupea pallasii-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+
+\newpage  
+
+(ref:l-disagg-her) Estimated abundance (upper panel) and biomass (lower panel) versus fork length ($L_F$, cm) for Pacific Herring (_Clupea pallasii_) in the core and nearshore survey regions.
+
+```{r l-disagg-her,fig.cap='(ref:l-disagg-her)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Clupea pallasii-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Clupea pallasii-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Clupea pallasii-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Clupea pallasii-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+``` 
+
+\newpage
+
+### Round Herring {#results-rher}
+
+The total estimated biomass of Round Herring was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.summ$biomass.cv[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)`%, **Table \@ref(tab:biomass-rher)**), and was located between Punta Eugenia and El Rosario off Baja CA and along a few transects north of San Nicolas Island in the SCB (**Fig. \@ref(fig:biom-dens-rher)a**). $L_F$ ranged from `r length.summ$L.min[length.summ$scientificName == 'Etrumeus acuminatus']` to `r length.summ$L.max[length.summ$scientificName == 'Etrumeus acuminatus']` cm with modes at 16, 23, and 26 cm (**Table \@ref(tab:l-freq-summ-rher)**, **Fig. \@ref(fig:l-disagg-rher)**). In the nearshore region, biomass was `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.ns$lower.ci.B[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` - `r prettyNum(be.all.ns$upper.ci.B[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t, CV = `r prettyNum(be.all.ns$biomass.cv[be.all.ns$Species == 'Etrumeus acuminatus'],big.mark=",",digits=1)`%; **Table \@ref(tab:biomass-rher)**, **Fig. \@ref(fig:biom-dens-rher)b**), or `r prettyNum((be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'] / (be.all.ns$Biomass[be.all.ns$Species == 'Etrumeus acuminatus'] + be.all$Biomass[be.all$Species == 'Etrumeus acuminatus']))*100,big.mark=",",digits=2)`% of the total biomass. It was distributed along the mainland coast near Long Beach and off the southern shore of Santa Catalina Island (**Fig. \@ref(fig:l-disagg-rher)**). All lengths in the nearshore region were 2-4 cm. (**Table \@ref(tab:l-freq-summ-rher)**, **Fig. \@ref(fig:l-disagg-rher)**).  
+
+(ref:biomass-rher) Biomass estimates (metric tons, t) and their precisions (upper and lower 95% confidence intervals, CI~95%~; and coefficients of variation, CVs) for Round Herring (_Etrumeus acuminatus_) in the core  and nearshore survey regions. Stratum areas are nmi^2^.
+
+```{r biomass-rher}
+be.table.sub.all <- be.table.summ %>% 
+  filter(Name == "Etrumeus acuminatus") %>% 
+  mutate(Region = "All")
+
+be.table.sub <- be.table %>% 
+  filter(Name == "Etrumeus acuminatus") %>% 
+  mutate(Region = "Core") 
+
+if (exists("be.table.ns")) {
+  be.table.sub.ns <- be.table.ns %>%
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Nearshore")
+  
+  be.table.sub <- be.table %>% 
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Core") %>% 
+    bind_rows(be.table.sub.ns) %>% 
+    bind_rows(be.table.sub.all) %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+} else {
+  be.table.sub <- be.table %>% 
+    filter(Name == "Etrumeus acuminatus") %>% 
+    mutate(Region = "Core") %>% 
+    ungroup() %>% 
+    select(Region, everything(), -Name, -Stock)
+}
+
+# Write results to CSV for stock assessors
+be.table.sub %>% 
+  rename("point_estimate" = "$\\hat{B}$",
+         "ci_lower" = "CI$_{L,95\\%}$",
+         "ci_upper" =	"CI$_{U,95\\%}$") %>%
+  write_csv(file = here("Output/biomass_final_Etrumeus_acuminatus_All.csv"),
+            na = "")
+
+if (nrow(be.table.sub) != 0) {
+  if (doc.type == "docx") {
+    regulartable(be.table.sub) %>% 
+      merge_v(j = c("Region")) %>%
+      add_header(Region  = "",
+                 # Stock    = "",
+                 Number   = "Stratum", Area = "Stratum", Transects = "Stratum", Distance = "Stratum",
+                 Clusters = "Trawl", Individuals = "Trawl",
+                 "$\\hat{B}$" = "Biomass", "CI$_{L,95\\%}$" = "Biomass", "CI$_{U,95\\%}$" = "Biomass",
+                 CV = "Biomass") %>% 
+      merge_h(part = "header") %>% 
+      align(align = "center",part = "header") %>% 
+      autofit()
+  } else {
+    kable(be.table.sub, format = knitr.format, booktabs = FALSE, escape = FALSE,
+          align           = c(rep("l", 1), rep("r",ncol(be.table.sub) - 2)),
+          digits          = c(0),
+          format.args     = list(big.mark = ","),
+          caption = '(ref:biomass-rher)') %>% 
+      kable_styling(latex_options = c("hold_position","scale_down"),
+                    position = "center",
+                    font_size = 8) %>% 
+      row_spec(nrow(be.table.sub), bold = T) %>% 
+      collapse_rows(columns = 1, valign = "top") %>%
+      add_header_above(c("Stratum" = 5, "Trawl" = 2, "Biomass" = 4))
+  }
+} else {
+  print("No results for this species/subpopulation.")
+}
+```  
+
+\newpage
+
+(ref:l-freq-summ-rher) Abundance estimates versus fork length ($L_F$, cm) for Round Herring (_Etrumeus acuminatus_) in the core region. No Round Herring were caught in the nearshore region.
+
+```{r l-freq-summ-rher,eval=TRUE}
+# Print table for round herring
+if ("Etrumeus acuminatus" %in% unique(abund.summ.all$Species)) {
+  abund.summ.table <- abund.summ.all %>% 
+    filter(Species == "Etrumeus acuminatus") %>% 
+    rename('$L_F$' = SL) %>% 
+    select(-Species, -Stock)
+  
+  if (nrow(abund.summ.table) != 0) {
+    if (doc.type == "docx") {
+      regulartable(abund.summ.table) %>% 
+        align(align = "center",part = "header") %>% 
+        autofit()
+    } else {
+      kable(abund.summ.table, format = "latex", booktabs = FALSE,
+            escape = FALSE, longtable = TRUE,
+            digits = c(0),
+            format.args = list(big.mark = ","),
+            caption = '(ref:l-freq-summ-rher)') %>%
+        kable_styling(latex_options = c("repeat_header")) %>%
+        add_header_above(c(" " = 1, "Region" = ncol(abund.summ.table)-1)) %>% 
+        row_spec(0, align = c("c"))   
+    }
+  }
+} else {
+  print("No Round Herring present.")
+}
+``` 
+
+\newpage
+
+(ref:biom-dens-rher) Biomass densities (colored points) of Round Herring (_Etrumeus acuminatus_), per stratum, in the a) core and b) nearshore survey regions. Overlaid are the locations of trawl clusters (blue numbers) or purse seine samples (red numbers) with at least one Round Herring in each stratum (colored polygons). Thick gray lines represent acoustic transects.
+
+```{r biom-dens-rher,eval=TRUE,fig.cap='(ref:biom-dens-rher)',out.width='6.5in',fig.pos='H'}
+# Include only for the core region; none collected in the nearshore region.
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_biomass_dens_combo_Etrumeus acuminatus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_combo_Etrumeus acuminatus-All.png"))
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+
+} else {
+
+  if (file.exists(here("Figs/fig_biomass_dens_Etrumeus acuminatus-All.png"))) {
+    include_graphics(here("Figs/fig_biomass_dens_Etrumeus acuminatus-All.png"))
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+```
+
+\newpage
+
+(ref:l-disagg-rher) Estimated abundance (upper panel) and biomass (lower panel) versus fork length ($L_F$, cm) for Round Herring (_Etrumeus acuminatus_) in the core survey region. No Round Herring were caught in the nearshore region.
+
+```{r l-disagg-rher,eval=TRUE,fig.cap='(ref:l-disagg-rher)',out.height='6in',fig.pos='H'}
+if (combine.regions) {
+  if (file.exists(here("Figs/fig_L_disagg_combo_Etrumeus acuminatus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_combo_Etrumeus acuminatus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  } 
+  
+} else {
+  if (file.exists(here("Figs/fig_L_disagg_Etrumeus acuminatus-All.png"))) {
+    include_graphics(here("Figs/fig_L_disagg_Etrumeus acuminatus-All.png"))  
+  } else {
+    print("No results for this species/subpopulation.")
+  }
+}
+``` 
+
+\newpage
+
+## Comparative nighttime trawl and purse seine sampling {#results-trawl-seine-comparison}
+
+```{r catch-comp-summary-data}
+# Load summary data if not present; if fails, source Code/comp_seine_2407RL.Rdata
+if (!exists("catch.comp.summ")) load(here("Output/catch_comp_summary.Rdata"))
+```
+
+_Lisa Marie_ conducted `r num2words(catch.comp.summ$n[catch.comp.summ$sample.type == "Purse seine"])` nighttime purse seine sets in close proximity to the `r num2words(catch.comp.summ$n[catch.comp.summ$sample.type == "Trawl"])` trawl locations sampled by _`r survey.vessel`_. In general, the species composition in catches from nighttime seine samples were visually similar to those in individual trawl hauls (**Fig. \@ref(fig:trawl-seine-comparison-haul)**) and trawl clusters (**Fig. \@ref(fig:trawl-seine-comparison-cluster)**). One notable exception was the two nearshore locations in the northern part of the area where purse seines collected Pacific Sardine but none were captured in the trawl net. Several of the purse seine samples contained no CPS, but those were farther offshore and nearby trawls contained Jack Mackerel and Pacific Mackerel.  
+
+Similar to species composition, the number and length distributions of CPS specimens were similar between purse seine and trawl samples **Fig. \@ref(fig:trawl-seine-comparison-lengths-combo)**). No Pacific Sardine were captured in the trawls, and no Northern Anchovy were collected in the purse seine samples; however, only one Northern Anchovy was collected in the trawls.   
+
+(ref:trawl-seine-comparison-haul) The proportion of CPS (by weight) in nighttime a) trawls and b) purse seines. Black points indicate trawl or purse seine samples where no CPS were collected.
+
+```{r trawl-seine-comparison-haul,eval=TRUE,fig.cap='(ref:trawl-seine-comparison-haul)',out.height='6in',fig.pos='H'}
+# Add catch comparison figure
+include_graphics(here("Figs/fig_trawl_haul_set_comp_map.png"))  
+``` 
+
+\newpage
+
+(ref:trawl-seine-comparison-cluster) The proportion of CPS (by weight) in nighttime a) trawl clusters and b) purse seines. Black points indicate trawl clusters or purse seine samples where no CPS were collected.
+
+```{r trawl-seine-comparison-cluster,eval=TRUE,fig.cap='(ref:trawl-seine-comparison-cluster)',out.height='6in',fig.pos='H'}
+# Add catch comparison figure
+include_graphics(here("Figs/fig_trawl_cluster_set_comp_map.png"))  
+``` 
+
+\newpage
+\blandscape
+
+(ref:trawl-seine-comparison-lengths-grid) Length distributions for CPS in nighttime purse seine samples by _Lisa Marie_ (top) and in trawl samples collected by _`r survey.vessel`_ (bottom).
+
+```{r trawl-seine-comparison-lengths-grid,fig.cap='(ref:trawl-seine-comparison-lengths-grid)',out.width='8in',fig.pos='H',eval=FALSE}
+
+# Add catch comparison figure
+include_graphics(here("Figs/fig_trawl_seine_lengths_comp_grid.png"))  
+``` 
+
+(ref:trawl-seine-comparison-lengths-combo) Length distributions for CPS in nighttime purse seine samples by _Lisa Marie_ and in trawl samples collected by _`r survey.vessel`_. Note: only one Northern Anchovy ($L_t$ = 177 mm) was collected in the trawls but is not presented here.
+
+```{r trawl-seine-comparison-lengths-combo,eval=TRUE,fig.cap='(ref:trawl-seine-comparison-lengths-combo)',out.width='8in',fig.pos='H'}
+
+# Add catch comparison figure
+include_graphics(here("Figs/fig_trawl_seine_lengths_comp_combo.png"))  
+``` 
+
+\elandscape
+\newpage
+
+# Discussion {#discussion}  
+
+The primary objective of the ATM surveys is to estimate the biomasses, distributions, and demographics of CPS within the survey area at the time of the survey. With the benefit of favorable weather conditions and minimal delays related to mechanical failures, staffing shortages, and other logistical challenges, nearly all of the originally allocated `r survey.das` sea days aboard _`r survey.vessel`_ were successfully executed, and the sampling of the core and nearshore regions in coordination with F/Vs _Long Beach Carnage_ and _Lisa Marie_ was accomplished with minimal temporal and spatial separation, all of which were testament to the planning, preparation, and skill of all parties involved. The `r tolower(survey.season)` `r survey.year` survey area spanned the expected distribution of the northern subpopulation of Pacific Sardine and northern subpopulation of Northern Anchovy in U.S. waters, but also portions of the expected distribution of the southern subpopulation of Pacific Sardine, central subpopulation of Northern Anchovy, Pacific Mackerel, Jack Mackerel, Pacific Herring, and Round Herring. 
+
+Due to sparse sampling by _Lisa Marie_ in the nearshore region, due in part to the general lack of schools to target but also to the presence of marine mammals that precluded setting their net, the nearest trawl cluster or purse-seine set was used to apportion backscatter in the nearshore region to minimize bias in the biomass estimates. In areas where marine mammals were abundant, Northern Anchovy were visually observed and, near San Francisco, were collected using sabiki rigs (K. Hinton, pers. comm.).  
+
+<!-- **[INCLUDE DISCUSSION OF NEARSHORE HABITAT/TEMPERATURES/MARINE MAMMAL PRESENCE THAT MAY HAVE AFFECTED THE DETECTION/SAMPLING OF NSP SARDINE IN THE NEARSHORE SURVEY. See email discussion with Josiah and Brad on 11/13 about conversations had during the nearshore survey follow-up.]**   -->
+
+<!-- **Comments from Brad: "did the mention of whales following sardine/anchovy into the nearshore areas (b/c it was cold the week they surveyed) north of SF ever make it into the report as an explanation that may have influenced the observed distribution?", "I recall LM saying the saw a ton of cps pushed up shallow (b/c cold further offshore) and historical amounts of whales feeding on them...prevented surveying and sampling. meanwhile the aerial survey was seeing fish nearshore too. seems to provide some useful information on distribution patterns given the survey has no replication.". ****"it just seems like a very common sense explanation and would help not force folks to draw too big of conclusions about shifts in distributions...would caution against that a bit at least yes?"**  Kevin asked for clarification on the "no replication" comment.  **"if it was cold by chance the one day they were at a spot, it would explain no fish....that doesn't mean they would also be gone from that area if they were there a few days earlier or later. It's the limitation of a snapshot."** **"I just recall LM folks saying that over and over during the meeting, and to me, it really explained a lot of the patterns observed in that single narrow time window the survey occurred."** -->
+
+The comparison of nighttime trawl and purse-seine samples yielded remarkably similar results in terms of both species and size composition. This is in contrast to purse-seine samples collected offshore by _Lisa Marie_ during daytime in 2022, where Jack Mackerel were reportedly schooling with Pacific Sardine but eluded capture, thereby biasing the species composition in those samples [@Stierhoff2023b], and provides support for using nighttime purse-seine catches to apportion backscatter observed farther offshore if necessary.  
+
+## Biomass and abundance
+### Northern Anchovy {#discussion-anchovy-biomass} 
+#### Northern subpopulation {#discussion-anchovy-biomass-northern} 
+
+The estimated biomass of the northern subpopulation of Northern Anchovy in the survey region north of Astoria was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Engraulis mordax" & be.all$Stock == "Northern"], big.mark=",", digits = 1)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Northern"],big.mark=",",digits=1)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Northern"],big.mark=",",digits=2)` t) in summer 2024. The northern subpopulation biomass has comprised a small fraction (`r round(min(biomass.pct.anch.n$biomass.pct),1)` to `r round(max(biomass.pct.anch.n$biomass.pct),1)`%) of the total CPS biomass in the CCE since at least 2015 [@Stierhoff2021a], and was lower than the `r prettyNum(biomass.pct.anch.n$biomass[biomass.pct.anch.c$year == 2021],big.mark=",",digits=5)` t observed in summer 2023 [@Stierhoff2024].  
+
+#### Central subpopulation {#discussion-anchovy-biomass-central} 
+
+The estimated biomass of the central subpopulation of Northern Anchovy in the survey region was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Engraulis mordax" & be.all$Stock == "Central"], big.mark=",", digits = 5)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Central"],big.mark=",",digits=5)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == "Engraulis mordax" & be.all.summ$Stock == "Central"],big.mark=",",digits=5)` t), making up `r round(be.all.summ$Biomass[be.all$Species == "Engraulis mordax" & be.all$Stock == "Central"]/sum(be.all.summ$Biomass)*100)`% of the total CPS biomass in summer 2024, and has comprised a substantial portion of the CPS biomass in the CCE since approximately 2016. The biomass in 2024 decreased `r prettyNum((1-(be.all.summ$Biomass[be.all.summ$Species == 'Engraulis mordax' & be.all.summ$Stock == "Central"]/biomass.pct.anch.c$biomass[biomass.pct.anch.c$year == 2023]))*100,,big.mark=",",digits=2)`% from the `r prettyNum(biomass.pct.anch.c$biomass[biomass.pct.anch.c$year == 2023],big.mark=",",digits=5)` t estimated in summer 2023 [@Stierhoff2024]. This estimate excludes an unquantified but relatively small amount of biomass attributed to deep Northern Anchovy schools in the nearshore region. Research will continue to better incorporate this biomass in any future revisions. Additional scrutiny of the 2023 survey data identified one acoustic transect near San Francisco with a significant CPS backscatter density that greatly increased both the point estimate and the confidence intervals (see **Fig. \@ref(fig:biomass-ts-combo)a**). For example, removing that transect reduced the 2023 biomass estimate by ~`r prettyNum((2700000-245000-945000)/2700000*100, digits = 2)`%, which would have resulted in a more gradual decrease in the biomass of the central subpopulation of Northern Anchovy over the past three survey years. The decrease in biomass in 2024 may also be due in part to the decreased northern extent of the distribution, which typically extends to Cape Mendocino but ended near San Francisco this year. We will continue exploring additional explanations for the apparent decline in biomass observed since 2022.  
+
+<!-- If this transect is removed, the biomass of the central subpopulation of Northern Anchovy in 2023 was approximately 945,000 t (700,000 t in core region and 245,000 t in nearshore region), which is comparable to the biomass estimated in 2024 but approximately 60% less than the biomass estimated in 2022.  -->
+
+<!-- **In summer 2024, the biomass of Northern Anchovy below the thermocline (>30 m depth) was `r prettyNum(241822-156926, big.mark=",", digits = 5)` t, which was `r round((241822-156926)/241822*100, 0)`% of the biomass in the nearshore region, and `r round((241822-156926)/be.all.summ$Biomass[be.all.summ$Species == "Engraulis mordax" & be.all$Stock == "Central"]*100, 1)`% of the biomass in the core and nearshore regions combined.**  -->
+
+### Pacific Sardine {#discussion-sardine}     
+#### Northern subpopulation {#discussion-sardine-biomass-northern} 
+
+The southern extent of northern subpopulation Pacific Sardine habitat was `r names(stock.break.sar)`, based on the potential habitat model [@Zwolinski2024] and corroborated by both the geographic separation of biomass density north and south of Point Conception (**Fig. \@ref(fig:tx-biom-dens)**) and visual differences in length compositions (**Fig. \@ref(fig:sardine-stock-allocation)**). The estimated biomass of `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Sardinops sagax" & be.all$Stock == "Northern"], big.mark=",", digits = 5)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Northern"], big.mark=",",digits=5)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Northern"], big.mark=",",digits=5)` t) in the survey region was virtually unchanged from the `r prettyNum(biomass.pct.sar.n$biomass[biomass.pct.sar.n$year == 2023],big.mark=",", digits = 5)` t estimated in summer 2023 [@Stierhoff2024]. However, unlike in past years, nearly all of the biomass attributed to the northern subpopulation was observed in the nearshore region near Pt. Conception and between Santa Cruz and San Francisco. These results were included in the update assessment used to provide a biomass estimate for harvest specifications of the northern subpopulation of Pacific Sardine during the 2025-2026 fishing year [@AllenAkselrud2025a]. Since 2014, the ATM biomass of the northern subpopulation of Pacific Sardine has remained less than the 150,000 t rebuilding target adopted by the Pacific Fishery Management Council in 2020^[https://www.pcouncil.org/documents/2020/08/g-1-attachment-1-pacific-sardine-rebuilding-plan-preliminary-environmental-analysis.pdf/] (**Figs. \@ref(fig:biomass-ts-combo)**). Japanese Sardine (_Sardinops melanosticta_) were present in the survey area during the survey period [@Longo2025], but all sardine were assumed to be _S. sagax_ for the purpose of estimating biomass. Therefore, biomass estimates for both the northern and southern subpopulations may be subject to change.  
+
+#### Southern subpopulation {#discussion-sardine-biomass-southern}  
+
+The estimated biomass of the southern subpopulation of Pacific Sardine was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Southern"], big.mark=",", digits = 5)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Southern"], big.mark=",",digits=5)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Southern"],big.mark=",",digits=5)` t), of which `r prettyNum(be.all.ns$Biomass[be.all.ns$Species == "Sardinops sagax" & be.all.ns$Stock == "Southern"], big.mark=",", digits = 5)` t (`r prettyNum(be.all.ns$Biomass[be.all.ns$Species == "Sardinops sagax" & be.all.ns$Stock == "Southern"]/be.all.summ$Biomass[be.all.summ$Species == "Sardinops sagax" & be.all.summ$Stock == "Southern"]*100, big.mark=",", digits = 1)`%) occurred in the nearshore region in the SCB. The southern subpopulation was first observed in U.S. waters by the SWFSC's ATM surveys in 2016 [`r prettyNum(biomass.pct.sar.s$biomass[biomass.pct.sar.s$year == 2016],big.mark=",", digits = 1)` t, @Stierhoff2021b]. Since then, the southern subpopulation biomass in U.S. waters has persisted. The biomass estimated in 2024 (`r prettyNum(biomass.pct.sar.s$biomass[biomass.pct.sar.s$year == 2024],big.mark=",", digits = 3)` t) is within the range of biomasses from `r prettyNum(biomass.pct.sar.s$biomass[biomass.pct.sar.s$year == 2019],big.mark=",", digits = 3)` t estimated in summer 2019 [@Stierhoff2020b] to `r prettyNum(biomass.pct.sar.s$biomass[biomass.pct.sar.s$year == 2021],big.mark=",", digits = 3)` t in summer 2021 [@Stierhoff2023a]. In 2017, the summer survey did not extend into the SCB [@Zwolinski2019a], and no summer survey was conducted in 2020 due to the COVID-19 pandemic. In 2024, Mexico conducted a contemporaneous survey of CPS, including the nearshore region, but those results are reported elsewhere [@MartinezMagana2025]. 
+
+<!-- **[UPDATE/REMOVE] Using the species proportions and lengths from purse-seine catches to apportion backscatter deeper than 30 m resulted in a biomass estimate of 207,320 t in the nearshore region and a total biomass of 213,768 t.**   -->
+
+### Pacific Mackerel {#discussion-mack}
+
+In summer 2024, the estimated biomass of Pacific Mackerel in the survey region was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Scomber japonicus'],big.mark=",",digits=3)` t), which is within the range of recent estimates (`r prettyNum(min(biomass.pct.mack$biomass[biomass.pct.mack$year %in% c(2016:2023)]),big.mark=",",digits=3)` - `r prettyNum(max(biomass.pct.mack$biomass[biomass.pct.mack$year %in% c(2016:2023)]),big.mark=",",digits=3)`) between 2016 and 2023.    
+
+### Jack Mackerel {#discussion-jack}  
+
+In summer 2024, the estimated biomass of Jack Mackerel in the survey region was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Trachurus symmetricus'],big.mark=",",digits=3)` t), which was a significant (`r round(be.all.summ$Biomass[be.all.summ$Species == 'Trachurus symmetricus']/biomass.pct.jack$biomass[biomass.pct.jack$year == 2023],1)*100`%) increase from the `r prettyNum(biomass.pct.jack$biomass[biomass.pct.jack$year == 2023],big.mark=",", digits = 5)` t estimated in summer 2023 [@Stierhoff2023a]. However, the 2023 survey suffered from a substantial loss of sea days and sampling effort, with the estimated biomass [`r prettyNum(biomass.pct.jack$biomass[biomass.pct.jack$year == 2023],big.mark=",", digits = 3)` t, @Stierhoff2024] being the lowest since 2017 [@Zwolinski2019a]. In 2024, the  estimate is more similar to the estimates from 2021 and 2022, and comprised `r round(be.all.summ$Biomass[be.all$Species == "Trachurus symmetricus"]/sum(be.all.summ$Biomass)*100)`% of the total CPS biomass.  
+
+### Pacific Herring {#discussion-herring} 
+
+In summer 2024, the estimated biomass of Pacific Herring in the survey region was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Clupea pallasii'],big.mark=",",digits=3)` t), which was a `r (1-round(((be.all.summ$Biomass[be.all.summ$Species == 'Clupea pallasii']/biomass.pct.her$biomass[biomass.pct.her$year == 2023])-1)*100,0))`% decrease from the `r prettyNum(biomass.pct.her$biomass[biomass.pct.her$year == 2023],big.mark=",", digits = 5)` t estimated in summer 2023 [@Stierhoff2024], but similar to estimates from 2021 and 2022 (`r prettyNum(biomass.pct.her$biomass[biomass.pct.her$year == 2021],big.mark=",", digits = 5)` t and `r prettyNum(biomass.pct.her$biomass[biomass.pct.her$year == 2022],big.mark=",", digits = 5)` t, respectively).  
+
+### Round Herring {#discussion-rherring} 
+
+In summer 2024, the estimated biomass of Round Herring in U.S. and Mexican waters north of Punta Eugenia was `r prettyNum(be.all.summ$Biomass[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t (CI~95%~ = `r prettyNum(be.all.summ$lower.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` - `r prettyNum(be.all.summ$upper.ci.B[be.all.summ$Species == 'Etrumeus acuminatus'],big.mark=",",digits=3)` t). While this is the first time that Round Herring biomass has been estimated in U.S. waters, specimens have been encountered in low numbers during past surveys (unpublished data).  
+
+(ref:sardine-stock-allocation) Summary of lengths for Pacific Sardine sampled during the summer 2024 survey:  a) relative length distribution of individuals classified as northern (blue) and southern (red) subpopulations (NSP and SSP, respectively); b) individual length measurements (grey points) and mean lengths (blue and red points for NSP and SSP, respectively) for each trawl cluster versus latitude; and c) locations of trawls clusters with Pacific Sardine assigned to each subpopulation (blue and red points) based on the predicted potential habitat for the NSP [@Zwolinski2024] at the midpoint of the survey (August 1, 2024).
+
+```{r sardine-stock-allocation,fig.cap='(ref:sardine-stock-allocation)',out.height='6.5in',fig.pos='H'}
+include_graphics(here("Images/img_sardine_stock_structure_lengths_summer2024.jpg"))  
+```
+
+\newpage
+
+## Ecosystem dynamics: Forage fish community {#discussion-ecosystem-dynamics}  
+
+The acoustic-trawl method (ATM) has been used to monitor the biomasses and distributions of pelagic and mid-water fish stocks worldwide [e.g., @Coetzee2008; @Karp1994; @Simmonds2009]. In 2006, the SWFSC's ATM survey in the CCE focused on Pacific Sardine [@Cutter2008], but evolved to assess the five most abundant CPS [@Zwolinski2014]: Pacific Sardine, Northern Anchovy, Jack Mackerel, Pacific Mackerel, and Pacific Herring. In the CCE, ATM surveys have been used to directly assess Pacific Hake [@JTC2014; @Edwards2018]; rockfishes [@Starr1996; @Demer2012b; @Demer2012c; @Demer2012d]; Pacific Herring [@Thomas2003]; northern subpopulation of Pacific Sardine [@Hill2017; @Kuriyama2020; @Kuriyama2022b]; northern [@Mais1974; @Mais1977] and central subpopulations [@Kuriyama2022a] of Northern Anchovy; and Pacific Mackerel [@Crone2015; @Crone2019]. The proportions of these subpopulations that are in water too shallow to be sampled by NOAA ships are estimated using samples collected from fishing vessels. Also, concurrent satellite- and ship-based measures of their biotic and abiotic habitats are used to provide an ecosystem perspective.  
+
+Collectively, these annual or bi-annual ATM surveys provide a unique insight into the dynamics of forage fishes in the CCE, including their distributions, abundances, interactions, and environments. For example, results from 2006 through 2013 indicate that Pacific Sardine dominated the CPS assemblage, but their biomass was declining [@Demer2012a; @Zwolinski2012a] and their seasonal migration was contracting [@Zwolinski2014]. Meanwhile, harvest rates for the declining subpopulation increased [@Demer2017], and the total forage-fish biomass decreased to less than 200,000 t in 2014 and 2015 (**Figs. \@ref(fig:biomass-ts-combo)a,b**). The U.S. fishery for Pacific Sardine was closed in 2015 [@NMFS2015], and there were reports of mass strandings, deaths, and reproductive failures in Brown Pelicans (_Pelecanus occidentalis_^[https://e360.yale.edu/features/brown_pelicans_a_test_case_for_the_endangered_species_act]), Common Murres (_Uria aalge_), Brandt’s Cormorants (_Phalacrocorax penicillatus_), and California sea lions (_Zalophus californianus_^[https://www.fisheries.noaa.gov/national/marine-life-distress/2013-2017-california-sea-lion-unusual-mortality-event-california]) [@McClatchie2016], all of which depend on forage species. The National Marine Fisheries Service deemed the subpopulation 'overfished' in 2019.  
+
+The biomass of the central subpopulation of Northern Anchovy, which had been growing rapidly since 2015,
+decreased from the estimate in 2023 [@Stierhoff2024]. After re-examination of the 2023 survey data, a single acoustic transect near San Francisco was identified as having significant influence on both the biomass point estimate and confidence intervals. In any case, the biomass of the central subpopulation of Northern Anchovy appears to have declined recently. Meanwhile, the northern and southern subpopulations of Pacific Sardine, delineated at Point Conception, were observed mostly in the nearshore region, with very little biomass north of San Francisco. Comparatively, in 2023, the subpopulations of Pacific Sardine were delineated at Bodega Bay, with the northern subpopulation observed predominantly off Washington and central Oregon [@Stierhoff2024]. However, because the change in distribution largely follows the geographical change in potential habitat, there is no indication that the biomasses of the northern or southern subpopulations of Pacific Sardine have changed significantly since summer 2023.  
+
+The survey-estimated CPS biomasses since 2008 were dominated by northern subpopulation Pacific Sardine until 2013, Jack Mackerel in 2014 and 2015, and then central subpopulation of Northern Anchovy since 2015, when it was resurgent. The latter subpopulation grew to ~2.75 million metric tons by 2021 [@Stierhoff2023a], and has hovered around ~2.5 million metric tons before decreasing recently. Meanwhile, the biomass of Pacific Mackerel remained the lowest in the assemblage, and the biomass of Jack Mackerel trended up from 2017 through 2022. In 2023, the delayed and smaller survey in the northern area created uncertainty about the decrease in Jack Mackerel biomass (**Fig. \@ref(fig:biomass-ts-combo)**), perhaps corroborated by the 2024 being between the 2021 and 2022 biomasses (**Fig. \@ref(fig:biomass-ts-combo)b**). In 2024, the biomass of Jack Mackerel was roughly equal to the biomass of the central subpopulation of Northern Anchovy, with each contributing to 41% and 45% of the total CPS biomass, respectively. The biomasses of northern and southern subpopulations of Pacific Sardine are calculated separately based on oceanographic habitat [@Zwolinski2024]. The southern subpopulation of Pacific Sardine has been present in U.S. waters since at least 2015, located mostly nearshore, south of Monterey Bay; the biomass of the northern subpopulation has been fluctuating below 100,000 t mostly off Oregon and Washington.  
+
+(ref:species-proportion-time-series) Distributions of species proportions in _`r survey.vessel`_’s nighttime trawl catches, summer 2015 through 2022. In 2015, the integrated CPS-hake survey sample northward of Vancouver Island. In 2017, there was no sampling in the SCB. In 2020, there was no survey due to the COVID-19 pandemic. In 2021, through a collaboration with Mexico, the CPS survey extended farther south into Baja California. In 2022, there was no nighttime trawl sampling north of Cape Mendocino, California. **[UPDATE TO INCLUDE 2023 RESULTS? OR REMOVE ALTOGETHER?]**
+
+```{r species-proportion-time-series,fig.cap='(ref:species-proportion-time-series)', out.width='9in',fig.pos='H',eval=FALSE}
+if (file.exists(here("Images/img_species_proportion_distributions_2015-2022.png"))) {
+  include_graphics(here("Images/img_species_proportion_distributions_2015-2022.png"))  
+} else {
+  print("No time series plot available.")
+} 
+```
+
+(ref:biomass-ts-line) Estimated biomasses ($t$) of the `r num2words(n_distinct(biomass.ts$group))` most abundant CPS populations or subpopulations of `r num2words(n_distinct(biomass.ts$species))` species in the CCE during summer since 2008. Surveys typically span the area between Cape Flattery and San Diego, but in some years also include Vancouver Island, Canada (2015-2019, 2024) and portions of Baja CA (2021-2022, 2024). Error bars are 95% confidence intervals.
+
+```{r biomass-ts-line,fig.cap='(ref:biomass-ts-line)', out.width='7in',fig.pos='H',eval=FALSE}
+if (file.exists(here("Figs/fig_biomass_ts_line.png"))) {
+  include_graphics(here("Figs/fig_biomass_ts_line.png"))  
+} else {
+  print("No time series plot available.")
+} 
+```
+
+(ref:biomass-ts-bar) Cumulative estimated biomass ($t$) of the `r num2words(n_distinct(biomass.ts$group))` most abundant CPS populations or subpopulations of `r num2words(n_distinct(biomass.ts$species))` species in the CCE during summer since 2008. Surveys typically span the area between Cape Flattery and San Diego, but in some years also include Vancouver Island, Canada (2015-2019, 2024) and portions of Baja CA (2021-2022, 2024).
+
+```{r biomass-ts-bar,fig.cap='(ref:biomass-ts-bar)', out.width='7in',fig.pos='H',eval=FALSE}
+if (file.exists(here("Figs/fig_biomass_ts_bar.png"))) {
+  include_graphics(here("Figs/fig_biomass_ts_bar.png"))  
+} else {
+  print("No time series bar chart available.")
+} 
+```
+
+(ref:biomass-ts-combo) a) Estimated and b) cumulative estimated biomasses ($t$) of the `r num2words(n_distinct(biomass.ts$group))` most abundant CPS populations or subpopulations of `r num2words(n_distinct(biomass.ts$species))` species in the CCE during summer since 2008. Surveys typically span the area between Cape Flattery and San Diego, but in some years also include Vancouver Island, Canada (2015-2019, 2024) and portions of Baja CA (2021-2022, 2024).
+
+```{r biomass-ts-combo,fig.cap='(ref:biomass-ts-combo)', out.width='7in',fig.pos='H'}
+if (file.exists(here("Figs/fig_biomass_ts_combo.png"))) {
+  include_graphics(here("Figs/fig_biomass_ts_combo.png"))  
+} else {
+  print("No time series combination bar chart available.")
+} 
+```
+
+\newpage
+
+# Acknowledgements {-}  
+
+The authors greatly appreciate that the ATM surveys require an enormous effort by multiple groups of people, particularly the SWFSC's Advanced Survey Technologies Program (Alice Beittel, Scott Mau, David Murfin, and Steve Sessions); Life History Program (Brad Erisman, Kelsey James, Bryan Overcash, Brittany Schwartzkopf, Zach Skelton, Owyn Snodgrass, and Lanora Vasquez de Mercado); Stock Assessment Program (Peter Kuriyama); and their volunteers. See **Appendix \@ref(appendix-scientific-personnel)** for a detailed account of all scientific personnel involved in this work. We also thank the officers and crew of _`r survey.vessel`_ and the SWFSC's Fisheries Resources Division administrative staff. The authors acknowledge that the methods used are the culmination of more than a half century of development efforts from numerous researchers from around the globe. We thank Capts. Rick Blair (_Lisa Marie_) and Rich Ashley, Tom Brinton, and Johny Marcopoulos (_Long Beach Carnage_), along with all the F/V crew members, for their coordination and cooperation during the nearshore sampling, and to Joel van Noord (CWPA) and Kristen Hinton (WDFW) for leading the at-sea collection and processing of purse-seine specimens. We thank Jennifer Topping (WDFW) for the ageing of biological samples from _Lisa Marie_. We thank Mark Fina (CWPA) and Diane Pleschner-Steele (Research Coordinator, CWPA) for contracting and coordinating the nearshore survey conducted by the _Long Beach Carnage_ off southern and central CA. Andy Blair [President, West Coast Pelagic Conservation Group (WCPCG)], Mike Okoniewski (Secretary, WCPCG), and Greg Shaughnessy (Vice President of WCPCG and Chief Operating Officer of Ocean Gold Seafoods) were integral in the permitting and planning for the nearshore sampling conducted by _Lisa Marie_ off WA, OR, and central and northern CA. We thank Sandy Diaz, Leeanne Laughlin, Heather Lee, Dane McDermott, and Trung Nguyen (CDFW) for their efforts to coordinate with and process samples from _Long Beach Carnage_, and Chelsea Protasio (CDFW) for coordinating the biological sampling and organizing, validating, and disseminating the resulting data. Critical reviews by Kevin Hill and Annie Yau improved this report.  
+
+\newpage  
+
+# References {-}  
+
+<div id = 'refs'></div>  
+
+\newpage  
+
+# (APPENDIX) Appendix {-}
+# Appendices {-} 
+
+# Scientific Personnel {#appendix-scientific-personnel}
+The collection and analysis of the survey data were conducted by members of 1-NOAA, 2-IMIPAS, 3-UCSC/CIMEAS, 5-OAI, 5-RAY Fellow, 6-volunteer, 7-OSU, 8-Cal Maritime, 9-WDFW, and 10-CWPA. For each leg, ^\*^ denotes the Cruise Leader, and ^+^ the Acoustic and Trawl Leads. The survey on _`r survey.vessel`_ was divided into four legs; operational readiness training (ORT) and MFT gear trials were conducted during the first five days of Leg 1, with some personnel transferred ashore via small boat transfer.  
+
+**Chief Scientist:**
+
+* J. Renfree^1^
+
+**Acoustic Data Collection and Processing:**  
+
+* MFT Trials: J. Renfree^1\*+^ and D. Murfin^1^
+* Leg I:      J. Renfree^1\*+^ and M. Vasquez Ortiz^2^
+* Leg II:     K. Stierhoff^1+^ and A. Beittel^1^
+* Leg III:    S. Mau^1+^ and A. White ^1^
+* Leg IV:     J. Zwolinski^3\*+^ and S. Sessions^1^  
+
+**Trawl Sampling:**
+
+* MFT Trials: K. James^1+^, D. Hernandez Cruz^2^, B. Overcash^1^, Z. Skelton^3^, B. Schwartzkopf^1^, and M. Vasquez Ortiz^2^
+* Leg I:    K. James^1+^, D. Hernandez Cruz^2^, P. Kuriyama^1^, B. Overcash^1^, and Z. Skelton^4^
+* Leg II:   T. Davies^7^, A. Johannsen^8^, A. Ostrowski^1^, L. Sartori^8^, and B. Schwartzkopf^1\*+^ 
+* Leg III:  T. Davies^7^, A. Malilay^1,5^, S. Mitchell^6^, Z. Skelton^4^, and O. Snodgrass^1\*+^ 
+* Leg IV:   A. Billings^1^, S. Dionson^1,5^, M. Liotta^1^, B. Overcash^1^, and R. Wildermuth^1^ 
+
+**Purse-seine Sampling:**  
+
+* _Lisa Marie_
+  + Z. Calef^9^ and K. Hinton^9^
+* _Long Beach Carnage_
+  + J. van Noord^10^
+
+**Echosounder Calibrations:**  
+
+* _Reuben Lasker_
+  + `r cal.personnel["RL"]`
+* _Long Beach Carnage_
+  + `r cal.personnel["LBC"]`
+* _Lisa Marie_
+  + `r cal.personnel["LM"]`
+  
+\newpage
+\blandscape
+
+# Calibration plots {#appendix-calibration-plots}
+## _Reuben Lasker_ {#appendix-calibration-plots-rl}
+### CW Mode {#appendix-calibration-plots-rl-cw}
+
+Relative beam-compensated target strength ($TS_{rel}$, dB re 1 m^2^) measurements of a WC38.1 sphere at `r echo.freqs["RL"]` kHz for echosounders aboard _`r survey.vessel`_. $TS_{rel}$ is calculated as the difference between the beam-compensated target strength ($TS_c$) and the theoretical target strength ($TS_{theory}$).
+
+```{r tsc-plot-rl, out.height='4.5in',fig.align='center',fig.pos='H'}
+include_graphics(here("Figs/fig_cal_TSrel_scatter_RL.png"))
+``` 
+
+\newpage
+
+### FM Mode {#appendix-calibration-plots-rl-fm}
+
+Measurements of on-axis gain ($G_0$, dB); alongship ($\alpha_\mathrm{-3dB}$, cyan) and athwartship ($\beta_\mathrm{-3dB}$, magenta) beamwidths (deg); and alongship ($\alpha_\mathrm{0}$, cyan) and athwartship ($\beta_\mathrm{0}$, magenta) offset angles (deg) measured during calibrations of EK80 wideband transceivers aboard _`r survey.vessel`_ (WBT; 38, 70, 120, 200, and 333 kHz) in frequency modulation (FM, or broadband) mode.
+
+```{r cal-plot-fm,out.height='4.5in',fig.align='center',fig.pos='H'}  
+# Plots generated using Code/processCal-FM.R
+include_graphics(here("Figs/fig_cal_FM_AllFreqs_RL.png"))
+```
+
+\newpage
+
+## _Lisa Marie_ {#appendix-calibration-plots-lm}
+
+Relative beam-compensated target strength ($TS_{rel}$, dB re 1 m^2^) measurements of a WC38.1 sphere at `r echo.freqs["LM"]` kHz for echosounders aboard _Lisa Marie_. $TS_{rel}$ is calculated as the difference between the beam-compensated target strength ($TS_c$) and the theoretical target strength ($TS_{theory}$). The results shown here are for the post-survey calibration conducted in Gig Harbor, WA.
+
+```{r tsc-plot-lm, out.height='4.5in',fig.align='center',fig.pos='H'}
+include_graphics(here("Figs/fig_cal_TSrel_scatter_LM.png"))
+```
+
+\newpage
+
+## _Long Beach Carnage_ {#appendix-calibration-plots-lbc}
+
+Relative beam-compensated target strength ($TS_{rel}$, dB re 1 m^2^) measurements of a WC38.1 sphere at `r echo.freqs["LBC"]` kHz for echosounders aboard _Long Beach Carnage_. $TS_{rel}$ is calculated as the difference between the beam-compensated target strength ($TS_c$) and the theoretical target strength ($TS_{theory}$).
+
+```{r tsc-plot-lbc, out.height='4.5in',fig.align='center',fig.pos='H'}
+include_graphics(here("Figs/fig_cal_TSrel_scatter_LBC.png"))
+```
+
+\elandscape
+\newpage
+
+# Length distributions and percent biomass by cluster {#appendix-cluster-length-percent}
+## Northern Anchovy {#appendix-cluster-length-percent-anchovy}  
+
+Standard length ($L_S$) frequency distributions of Northern Anchovy (_Engraulis mordax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.  
+
+(ref:rlf-anchovy) Standard length ($L_S$) frequency distributions of Northern Anchovy (_Engraulis mordax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-anchovy,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Engraulis mordax.png"))
+```  
+
+\newpage
+
+## Pacific Sardine {#appendix-cluster-length-percent-sardine}  
+
+Standard length ($L_S$) frequency distributions of Pacific Sardine (_Sardinops sagax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum. The southern subpopulation are comprised of stratum 1 and 2, while the northern subpopulation are stratum 3, 4, and 5.  
+
+(ref:rlf-sardine) Standard length ($L_S$) frequency distributions of Pacific Sardine (_Sardinops sagax_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-sardine,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Sardinops sagax.png"))
+```  
+
+\newpage  
+
+## Pacific Mackerel {#appendix-cluster-length-percent-mack}  
+
+Fork length ($L_F$) frequency distributions of Pacific Mackerel (_Scomber japonicus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.  
+
+(ref:rlf-mack) Fork length ($L_F$) frequency distributions of Pacific Mackerel (_Scomber japonicus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-mack,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Scomber japonicus.png"))
+```  
+
+\newpage
+
+## Jack Mackerel {#appendix-cluster-length-percent-jack}  
+
+Fork length ($L_F$) frequency distributions of Jack Mackerel (_Trachurus symmetricus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.  
+
+(ref:rlf-jack) Fork length ($L_F$) frequency distributions of Jack Mackerel (_Trachurus symmetricus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-jack,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Trachurus symmetricus.png"))
+```  
+
+\newpage
+
+## Pacific Herring {#appendix-cluster-length-percent-her}  
+
+Fork length ($L_F$) frequency distributions of Pacific Herring (_Clupea pallasii_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.  
+
+(ref:rlf-her) Fork length ($L_F$) frequency distributions of Pacific Herring (_Clupea pallasii_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-her,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Clupea pallasii.png"))
+```  
+
+\newpage
+
+## Round Herring {#appendix-cluster-length-percent-rher}
+
+Fork length ($L_F$) frequency distributions of Round Herring (_Etrumeus acuminatus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+(ref:rlf-rher) Fork length ($L_F$) frequency distributions of Round Herring (_Etrumeus acuminatus_) per nighttime trawl cluster, annotated with the number of individuals caught and their percentage contributions to the abundance in each stratum.
+
+```{r rlf-rher,out.height='6.5in',fig.pos='H'}
+include_graphics(here("Figs/fig_cluster_relative_length_frequency_Etrumeus acuminatus.png"))
+```
+
+\newpage

--- a/Doc/settings/output_2506SH.R
+++ b/Doc/settings/output_2506SH.R
@@ -1,0 +1,92 @@
+# Load output from estimateBiomass ----------------------------------------
+# Load biomass estimate tables
+load(here("Output/biomass_bootstrap_estimates_final.Rdata"))
+load(here("Output/biomass_bootstrap_estimates_final_ns.Rdata"))
+load(here("Output/biomass_bootstrap_estimates_final_nse.Rdata"))
+
+# Get survey estimates for all strata
+be.all     <- be %>% 
+  mutate(Region = "Core") %>% 
+  select(Species, Stock, Region, everything()) %>% 
+  filter(Stratum == "All")
+be.all.ns  <- be.ns %>%
+  mutate(Region = "Nearshore") %>%
+  select(Species, Stock, Region, everything()) %>%
+  filter(Stratum == "All")
+be.all.nse <- be.nse %>% 
+  mutate(Region = "NSE") %>% 
+  select(Species, Stock, Region, everything()) %>% 
+  filter(Stratum == "All")
+
+# Summarise biomass for all regions included in the final estimates
+be.all.var <- be.all %>% 
+  bind_rows(be.all.ns) %>%
+  select(Species, Stock, biomass.sd) %>% 
+  group_by(Species, Stock) %>%
+  summarise(biomass.sd = sqrt(sum(biomass.sd^2)))
+
+# Combine core and nearshore biomass
+be.all.summ <- be.all %>% 
+  bind_rows(be.all.ns) %>%
+  group_by(Species, Stock) %>% 
+  select(-Region, -Stratum, -biomass.sd, -biomass.cv) %>% 
+  summarise_all(list(sum)) %>% 
+  left_join(be.all.var) %>% 
+  mutate(biomass.cv = biomass.sd/Biomass*100)
+
+# Load abundance and length summaries
+load(here("Output/length_summary_all.Rdata")) # Length and weight ranges
+load(here("Output/length_frequency_summary.Rdata"))
+load(here("Output/abundance_table_all.Rdata"))
+load(here("Output/abundance_table_all_ns.Rdata"))
+
+# Summarise length-disaggregated abundances to describe length ranges
+length.summ <- abund.summ %>% 
+  filter(biomass != 0) %>% 
+  group_by(scientificName = Species, stock = Stock) %>% 
+  summarise(L.min = min(TL),
+            L.max = max(TL))
+
+# Combine abundance summaries for tables
+abund.summ.all <- abund.summ %>% 
+  mutate(Region = "Core") %>% 
+  bind_rows(abund.summ.ns) %>%
+  filter(!is.nan(abundance)) %>% 
+  ungroup() %>% 
+  select(Species, Stock, Region, SL, abundance) %>%
+  pivot_wider(names_from = Region, 
+              values_from = abundance, 
+              values_fn = list(abundance = sum)) %>% 
+  select(Species, Stock, SL, all_of(estimate.regions)) 
+  
+# Load trawl information
+load(here("Output/haul_info.Rdata"))
+load(here("Output/catch_info.Rdata"))
+# load(here("Output/species_codes.Rdata"))
+
+# Load NASC summaries
+## SH
+load(here("Output/nasc_summ_tx.Rdata"))
+
+## Offshore
+if (file.exists(here("Output/nasc_summ_tx_os.Rdata"))) {
+  load(here("Output/nasc_summ_tx_os.Rdata"))
+  nasc.summ.sd.os <- filter(nasc.summ.os, str_detect(vessel.name, "SD"))
+  nasc.summ.rl.os <- filter(nasc.summ.os, str_detect(vessel.name, "RL"))  
+}
+
+## Nearshore
+if (file.exists(here("Output/nasc_summ_tx_ns.Rdata"))) {
+  load(here("Output/nasc_summ_tx_ns.Rdata"))
+}
+
+# Load transect spacing
+load(here("Output/transect_spacing.Rdata"))
+
+# # Load calibration results
+# load(here("Output/cal_output_table.Rdata"))
+# 
+# # Load purse seine data
+# load(here("Output/purse_seine_lengths.Rdata"))
+# load(here("Output/purse_seine_sets.Rdata"))
+

--- a/Doc/settings/settings_2506SH.R
+++ b/Doc/settings/settings_2506SH.R
@@ -6,14 +6,15 @@ process.nearshore <- T # Process near backscatter data; typically TRUE
 estimate.ns       <- T # Estimate biomass in the nearshore strata; T if nearshore surveyed
 process.offshore  <- F # Process offshore backscatter data
 estimate.os       <- F # Estimate biomass in the offshore strata; T if offshore surveyed
-combine.regions   <- F # Combine nearshore/offshore plots with those from the core region
+combine.regions   <- T # Combine nearshore/offshore plots with those from the core region
 
 # Survey planning ---------------------------------------------------------
 ## This section controls and configures settings used by makeTransects and checkTransects for generating and checking survey transects
 ### Transect spacing (nautical miles)
 tx.spacing.fsv  <- 15 # For Lasker 
 tx.spacing.sd   <- 15 # For Saildrone
-tx.spacing.ns   <- 7 # For nearshore sampling
+tx.break.ns     <- 52 # Northernmost transect sampled by the southern F/V, 64 in 2024, near Carmel
+tx.spacing.ns   <- c("S" = 7, "N" = 7, "CI" = 2.5) # or NA
 tx.spacing.os   <- 40 # Nearshore transect spacing, in nmi; set NA if calculating programatically
 
 # Mainland buffer distance for FSV and Saildrone transects
@@ -435,7 +436,7 @@ seine.vessels.long     <- c("LBC" = "Long Beach Carnage",
 
 # Deep backscatter correction
 # Correct deep backscatter?
-adj.deep.nasc <- TRUE
+adj.deep.nasc <- FALSE
 # Remove deep backscatter, if a correction is not applied? Set to FALSE if adj.deep.nasc = TRUE
 rm.deep.nasc <- FALSE
 # Vessels for which to remove deep backscatter that may be anchovy
@@ -671,7 +672,7 @@ boot.num <- 5 # 1000 during final
 do.lf    <- TRUE
 
 # Define regions to present in main Results
-estimate.regions   <- c("Core") # Add "Nearshore"
+estimate.regions   <- c("Core", "Nearshore")
 
 # Define rules for selecting and pruning sampling strata -----------------------
 # Defines breaks between strata
@@ -699,7 +700,7 @@ if ("SD" %in% nasc.vessels) {
     data.frame(
       scientificName = "Clupea pallasii",
       stratum = 1,
-      transect = 30:37),
+      transect = 30:39),
     data.frame(
       scientificName = "Engraulis mordax",
       stratum = 1,
@@ -736,10 +737,18 @@ if ("SD" %in% nasc.vessels) {
       scientificName = "Scomber japonicus",
       stratum = 1,
       transect = 1:4),
-    # data.frame(
-    #   scientificName = "Scomber japonicus",
-    #   stratum = 2,
-    #   transect = 16:19),
+    data.frame(
+      scientificName = "Scomber japonicus",
+      stratum = 2,
+      transect = 16:19),
+    data.frame(
+      scientificName = "Scomber japonicus",
+      stratum = 3,
+      transect = 23:25),
+    data.frame(
+      scientificName = "Scomber japonicus",
+      stratum = 4,
+      transect = 41:42),
     data.frame(
       scientificName = "Trachurus symmetricus",
       stratum = 1,
@@ -747,7 +756,7 @@ if ("SD" %in% nasc.vessels) {
     data.frame(
       scientificName = "Trachurus symmetricus",
       stratum = 2,
-      transect = 15:37))
+      transect = 15:42))
 }
 
 # Stock boundaries --------------------------------------------------------


### PR DESCRIPTION
First full run of estimateBiomass and estimateNearshore without yet having seine data to apportion nearshore backscatter. New workflow does not require seine data, and can use only trawl data (one or the other is required). Other minor updates to avoid breaking changes.

New files were created to report biomass estimates for 2025.